### PR TITLE
feat: future_covariates in TiDE training + CI bands on New Prediction gauge

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -151,6 +151,7 @@ def evaluate_split(model, target, covariates, start, name):
     preds = model.historical_forecasts(
         series=target,
         past_covariates=covariates,
+        future_covariates=covariates,
         start=start,
         forecast_horizon=OUTPUT_CHUNK,
         stride=1,
@@ -260,8 +261,10 @@ def main():
     model.fit(
         series=target_train,
         past_covariates=cov_full[:TRAIN_SIZE],
+        future_covariates=cov_full[:TRAIN_SIZE],
         val_series=target_val,
         val_past_covariates=cov_full,
+        val_future_covariates=cov_full,
         verbose=True,
     )
 
@@ -285,6 +288,7 @@ def main():
     full_preds = model.historical_forecasts(
         series=target,
         past_covariates=cov_full,
+        future_covariates=cov_full,
         start=INPUT_CHUNK,
         forecast_horizon=OUTPUT_CHUNK,
         stride=1,


### PR DESCRIPTION
## Summary

- **training/train.py**: added `future_covariates` to `model.fit()`, `evaluate_split()`, and `historical_forecasts()` so the model learns the covariate-to-target relationship in both directions
- **dashboard/app.py — New Prediction tab**: complete rewrite of `score_new_document` callback using TiDE with database context:
  - Fetches last 15 FSI values (target series) + article embeddings (past+future covariates) from DB
  - New article embedding merged into today's covariate pool
  - Dynamic `n` = business days from `last_fsi_date` (exclusive) to today (inclusive)
  - Covariate series extended +1 extra business day to satisfy Darts' validation for `n > output_chunk_length`
  - 95% CI computed as `score ± 1.96 × test_rmse` (calibrated from held-out test set; MC dropout produces zero variance on this model due to small hidden_size + layer_norm)
  - Gauge shows two white CI marker steps on the arc + `95% CI: [lo — hi]` annotation
  - PyTorch 2.6 fix: `torch.load` patched with `weights_only=False` in `load_artifacts()`

## Test plan
- [ ] New Prediction tab loads without error
- [ ] Pasting a text and clicking "Score Document" returns a gauge with score + non-collapsed CI
- [ ] Label chip shows `LABEL (score) 95% CI [lo — hi]`
- [ ] Historical Results tab still works (time series chart + model quality panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)