### PR TITLE
[DASH-01] Rename tabs to Entrenamiento and Predicciones

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -147,13 +147,13 @@ app.layout = html.Div(
             style={"backgroundColor": "#161b22"},
             children=[
                 dcc.Tab(
-                    label="Historical Results",
+                    label="Entrenamiento",
                     value="tab-history",
                     style={"color": "#8b949e", "backgroundColor": "#161b22"},
                     selected_style={"color": "#e6edf3", "backgroundColor": "#0d1117", "borderTop": "2px solid #388bfd"},
                 ),
                 dcc.Tab(
-                    label="New Prediction",
+                    label="Predicciones",
                     value="tab-predict",
                     style={"color": "#8b949e", "backgroundColor": "#161b22"},
                     selected_style={"color": "#e6edf3", "backgroundColor": "#0d1117", "borderTop": "2px solid #388bfd"},


### PR DESCRIPTION
## Summary
- Renames tab label "Historical Results" → "Entrenamiento"
- Renames tab label "New Prediction" → "Predicciones"
- Internal `value` props unchanged — no callback impact

Closes #30

## Test plan
- [ ] Open dashboard at http://localhost:8050 — verify tab labels show "Entrenamiento" and "Predicciones"
- [ ] Click each tab — verify content renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)