### PR TITLE
[DB-01] Schema migration: fsi_components, training_predictions, daily_predictions

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -54,6 +54,31 @@ CREATE TABLE IF NOT EXISTS fsi_target (
     date      TEXT NOT NULL UNIQUE,
     fsi_value REAL NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS fsi_components (
+    date        TEXT NOT NULL UNIQUE,
+    merv_vol    REAL,
+    argt_spread REAL,
+    usd_ars     REAL,
+    emb_spread  REAL
+);
+
+CREATE TABLE IF NOT EXISTS training_predictions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    date          TEXT NOT NULL,
+    fsi_actual    REAL,
+    fsi_pred      REAL NOT NULL,
+    split         TEXT NOT NULL,
+    model_version TEXT NOT NULL,
+    UNIQUE (date, split)
+);
+
+CREATE TABLE IF NOT EXISTS daily_predictions (
+    date          TEXT NOT NULL UNIQUE,
+    fsi_pred      REAL NOT NULL,
+    model_version TEXT,
+    predicted_at  TEXT DEFAULT (datetime('now'))
+);
 """
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -51,3 +51,28 @@ CREATE TABLE IF NOT EXISTS fsi_target (
     date      DATE  NOT NULL UNIQUE,
     fsi_value FLOAT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS fsi_components (
+    date         DATE  NOT NULL UNIQUE,
+    merv_vol     FLOAT,
+    argt_spread  FLOAT,
+    usd_ars      FLOAT,
+    emb_spread   FLOAT
+);
+
+CREATE TABLE IF NOT EXISTS training_predictions (
+    id            SERIAL PRIMARY KEY,
+    date          DATE  NOT NULL,
+    fsi_actual    FLOAT,
+    fsi_pred      FLOAT NOT NULL,
+    split         VARCHAR(10) NOT NULL,
+    model_version VARCHAR(255) NOT NULL,
+    UNIQUE (date, split)
+);
+
+CREATE TABLE IF NOT EXISTS daily_predictions (
+    date          DATE         NOT NULL UNIQUE,
+    fsi_pred      FLOAT        NOT NULL,
+    model_version VARCHAR(255),
+    predicted_at  TIMESTAMP    DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- Adds `fsi_components` table: z-scored market components used for FSI PCA (written by `build_fsi_target.py`)
- Adds `training_predictions` table: out-of-sample val/test predictions from training pipeline (written by `train.py`)
- Adds `daily_predictions` table: daily pipeline scores (written by `daily_pipeline.py`)
- `predictions` table retained for backwards compatibility but no longer written to
- Works in both PostgreSQL (Docker) and SQLite (local)

Closes #31

## Test plan
- [ ] `docker compose run --rm app python src/data/build_fsi_target.py` → `fsi_components` populated
- [ ] `docker compose run --rm app python training/train.py` → `training_predictions` has val + test rows
- [ ] `docker compose run --rm app python src/ingestion/daily_pipeline.py` → `daily_predictions` has a row
- [ ] pgAdmin confirms all 3 tables exist and have data

🤖 Generated with [Claude Code](https://claude.com/claude-code)