### PR TITLE
[ML-02] Optuna hyperparameter optimisation for TiDE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 DATABASE_URL=postgresql://bapro:bapro_pass@postgres:5432/bapro_stress
+OPTUNA_N_TRIALS=3
+OPTUNA_TOP_K=2
+OPTUNA_DB_URL=postgresql://bapro:bapro_pass@postgres:5432/bapro_stress

--- a/config.py
+++ b/config.py
@@ -20,3 +20,11 @@ TIDE_MODEL_PATH = os.getenv("TIDE_MODEL_PATH", str(_REPO_ROOT / "artifacts" / "t
 
 LOGS_DIR = Path(os.getenv("LOGS_DIR", str(_REPO_ROOT / "logs")))
 FSI_CSV = _REPO_ROOT / "data" / "fsi_target.csv"
+
+# Optuna hyperparameter search
+OPTUNA_N_TRIALS = int(os.getenv("OPTUNA_N_TRIALS", "3"))
+OPTUNA_TOP_K    = int(os.getenv("OPTUNA_TOP_K",    "2"))
+OPTUNA_DB_URL   = os.getenv(
+    "OPTUNA_DB_URL",
+    f"sqlite:///{_REPO_ROOT / 'artifacts' / 'optuna.db'}",
+)

--- a/db/connection.py
+++ b/db/connection.py
@@ -79,6 +79,21 @@ CREATE TABLE IF NOT EXISTS daily_predictions (
     model_version TEXT,
     predicted_at  TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS optuna_trials (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    study_name    TEXT    NOT NULL,
+    trial_number  INTEGER NOT NULL,
+    rank_val      INTEGER NOT NULL,
+    mape_val      REAL    NOT NULL,
+    mape_test     REAL,
+    mae_test      REAL,
+    rmse_test     REAL,
+    is_production INTEGER DEFAULT 0,
+    hyperparams   TEXT    NOT NULL,
+    model_version TEXT,
+    created_at    TEXT    DEFAULT (datetime('now'))
+);
 """
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -76,3 +76,18 @@ CREATE TABLE IF NOT EXISTS daily_predictions (
     model_version VARCHAR(255),
     predicted_at  TIMESTAMP    DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS optuna_trials (
+    id            SERIAL PRIMARY KEY,
+    study_name    VARCHAR(255) NOT NULL,
+    trial_number  INT          NOT NULL,
+    rank_val      INT          NOT NULL,
+    mape_val      FLOAT        NOT NULL,
+    mape_test     FLOAT,
+    mae_test      FLOAT,
+    rmse_test     FLOAT,
+    is_production BOOLEAN      DEFAULT FALSE,
+    hyperparams   TEXT         NOT NULL,
+    model_version VARCHAR(255),
+    created_at    TIMESTAMP    DEFAULT NOW()
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ requests==2.32.5
 fredapi==0.5.1
 jupyter==1.1.1
 nbconvert==7.16.4
+optuna>=3.6.0

--- a/training/train.py
+++ b/training/train.py
@@ -1,12 +1,14 @@
 """
-Training step — Darts TiDE model on real FSI data.
+Training pipeline — Darts TiDE with Optuna hyperparameter optimisation.
 
-Joins articles + article_embeddings + fsi_target on date.
-Mean-pools article embeddings per day to produce one 384-dim vector.
-Splits 70/15/15 by row count (temporal order preserved).
-Trains TiDE with 384-dim embeddings as past covariates.
-Saves artifacts/tide_model.pt + artifacts/metadata.json.
-Writes all-sample predictions back to the predictions table.
+Workflow:
+  1. Optuna runs N_TRIALS, each trained on TRAIN (70%), evaluated on VAL (15%).
+  2. Top-K trials by MAPE_val advance to test evaluation.
+  3. Each finalist is retrained on TRAIN+VAL and evaluated on TEST (15%).
+  4. The trial with best MAPE_test becomes the production model.
+  5. Production model is retrained on the full dataset (TRAIN+VAL+TEST).
+  6. Out-of-sample val/test predictions written to training_predictions table.
+  7. Trial results written to optuna_trials table.
 
 Usage:
     python training/train.py
@@ -23,98 +25,81 @@ import pandas as pd
 from sqlalchemy import text
 
 from db.connection import get_engine
-from config import ARTIFACTS_DIR, TIDE_MODEL_PATH
+from config import (
+    ARTIFACTS_DIR, TIDE_MODEL_PATH,
+    OPTUNA_N_TRIALS, OPTUNA_TOP_K, OPTUNA_DB_URL,
+)
 
 from darts import TimeSeries
 from darts.models import TiDEModel
-from darts.metrics import mae, rmse
+from darts.metrics import mae, rmse, mape as darts_mape
 
 # ---------------------------------------------------------------------------
 # Split fractions
 # ---------------------------------------------------------------------------
 TRAIN_PCT = 0.70
 VAL_PCT   = 0.15
-# TEST_PCT  = 0.15  (remainder)
 
-INPUT_CHUNK  = 2
 OUTPUT_CHUNK = 1
-
+STUDY_NAME   = "tide_bapro"
 
 # ---------------------------------------------------------------------------
-# Data loading — real corpus (articles + fsi_target)
+# Data loading
 # ---------------------------------------------------------------------------
 
 def load_dataset(engine):
     """
     Join articles + article_embeddings + fsi_target on date.
-    Mean-pool all article embeddings per business day.
-
-    Returns DataFrame with columns: date (datetime), vec (np.array), fsi_value (float).
+    Mean-pool embeddings per business day.
+    Returns DataFrame: date (datetime), vec (np.array), fsi_value (float).
     """
-    is_pg = not engine.url.drivername.startswith("sqlite")
-
     with engine.connect() as conn:
-        # Get all fsi_target dates
         fsi_rows = conn.execute(
             text("SELECT date, fsi_value FROM fsi_target ORDER BY date")
         ).fetchall()
-
-        # Get all article embeddings with their dates
         emb_rows = conn.execute(
             text(
-                """
-                SELECT a.date, ae.embedding
-                FROM article_embeddings ae
-                JOIN articles a ON a.id = ae.id
-                ORDER BY a.date
-                """
+                "SELECT a.date, ae.embedding "
+                "FROM article_embeddings ae "
+                "JOIN articles a ON a.id = ae.id "
+                "ORDER BY a.date"
             )
         ).fetchall()
 
     if not fsi_rows:
-        raise RuntimeError("fsi_target table is empty. Run make seed_fsi first.")
+        raise RuntimeError("fsi_target table is empty. Run seed_fsi first.")
     if not emb_rows:
-        raise RuntimeError("article_embeddings table is empty. Run make embed first.")
+        raise RuntimeError("article_embeddings table is empty. Run embed first.")
 
-    # Build per-day embedding dict (mean-pool)
     date_vecs: dict[str, list] = {}
     for row in emb_rows:
         date_str = str(row[0])[:10]
-        emb_raw = row[1]
+        emb_raw  = row[1]
         vec = np.array(
             json.loads(emb_raw) if isinstance(emb_raw, str) else list(emb_raw),
             dtype=np.float32,
         )
-        if date_str not in date_vecs:
-            date_vecs[date_str] = []
-        date_vecs[date_str].append(vec)
+        date_vecs.setdefault(date_str, []).append(vec)
 
-    mean_vecs: dict[str, np.ndarray] = {
-        d: np.mean(vecs, axis=0) for d, vecs in date_vecs.items()
-    }
-
-    # Determine embedding dimension from first available vec
-    emb_dim = next(iter(mean_vecs.values())).shape[0] if mean_vecs else 384
-    zero_vec = np.zeros(emb_dim, dtype=np.float32)
+    mean_vecs = {d: np.mean(vecs, axis=0) for d, vecs in date_vecs.items()}
+    emb_dim   = next(iter(mean_vecs.values())).shape[0] if mean_vecs else 384
+    zero_vec  = np.zeros(emb_dim, dtype=np.float32)
 
     records = []
     for row in fsi_rows:
         date_str = str(row[0])[:10]
-        fsi_val = float(row[1])
-        # Use zero vector for days without articles so the target has no gaps
-        vec = mean_vecs.get(date_str, zero_vec)
-        records.append({"date": date_str, "vec": vec, "fsi_value": fsi_val})
+        records.append({
+            "date":      date_str,
+            "vec":       mean_vecs.get(date_str, zero_vec),
+            "fsi_value": float(row[1]),
+        })
 
     if not records:
-        raise RuntimeError(
-            "No overlap between fsi_target and article_embeddings dates. "
-            "Run backfill first."
-        )
+        raise RuntimeError("No overlap between fsi_target and article_embeddings.")
 
     df = pd.DataFrame(records)
     df["date"] = pd.to_datetime(df["date"])
-    df = df.sort_values("date").reset_index(drop=True)
-    return df
+    return df.sort_values("date").reset_index(drop=True)
 
 
 # ---------------------------------------------------------------------------
@@ -124,31 +109,66 @@ def load_dataset(engine):
 def build_target_series(df):
     return TimeSeries.from_dataframe(
         df, time_col="date", value_cols="fsi_value",
-        fill_missing_dates=True, freq="B"
+        fill_missing_dates=True, freq="B",
     )
 
 
 def build_covariate_series(df):
     dim = len(df.iloc[0]["vec"])
     mat = np.stack(df["vec"].values).astype(np.float32)
-    cov_df = pd.DataFrame(
-        mat,
-        index=df["date"].values,
-        columns=[f"emb_{i}" for i in range(dim)],
-    )
+    cov_df = pd.DataFrame(mat, index=df["date"].values,
+                          columns=[f"emb_{i}" for i in range(dim)])
     cov_df.index = pd.DatetimeIndex(cov_df.index)
     ts = TimeSeries.from_dataframe(cov_df, fill_missing_dates=True, freq="B")
-    # Fill NaN (days without articles) with zero vectors
-    filled_df = ts.to_dataframe().fillna(0.0)
-    return TimeSeries.from_dataframe(filled_df, freq="B")
+    return TimeSeries.from_dataframe(ts.to_dataframe().fillna(0.0), freq="B")
 
 
 # ---------------------------------------------------------------------------
-# Evaluation helper
+# Model factory
 # ---------------------------------------------------------------------------
 
-def evaluate_split(model, target, covariates, start, name):
-    preds = model.historical_forecasts(
+def _build_model(params: dict, work_dir: str, model_name: str,
+                 progress: bool = False) -> TiDEModel:
+    """Instantiate a TiDE model with given hyperparams and optional CSVLogger."""
+    input_chunk = params["input_chunk_length"]
+
+    pl_kwargs: dict = {"enable_progress_bar": progress}
+    try:
+        from pytorch_lightning.loggers import CSVLogger
+        log_dir = Path(work_dir) / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        pl_kwargs["logger"] = CSVLogger(save_dir=str(log_dir), name="", version="")
+    except ImportError:
+        pass
+
+    return TiDEModel(
+        input_chunk_length=input_chunk,
+        output_chunk_length=OUTPUT_CHUNK,
+        num_encoder_layers=params.get("num_encoder_layers", 1),
+        num_decoder_layers=params.get("num_decoder_layers", 1),
+        decoder_output_dim=params.get("decoder_output_dim", 8),
+        hidden_size=params["hidden_size"],
+        temporal_width_past=min(4, input_chunk),
+        temporal_width_future=min(4, input_chunk),
+        use_layer_norm=True,
+        dropout=params["dropout"],
+        n_epochs=params["n_epochs"],
+        batch_size=params["batch_size"],
+        optimizer_kwargs={"lr": params["lr"]},
+        model_name=model_name,
+        work_dir=work_dir,
+        save_checkpoints=False,
+        force_reset=True,
+        pl_trainer_kwargs=pl_kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _historical_forecasts(model, target, covariates, start):
+    return model.historical_forecasts(
         series=target,
         past_covariates=covariates,
         future_covariates=covariates,
@@ -158,11 +178,25 @@ def evaluate_split(model, target, covariates, start, name):
         retrain=False,
         verbose=False,
     )
+
+
+def _eval_metrics(target, preds):
     actual = target.slice_intersect(preds)
-    split_mae = float(mae(actual, preds))
-    split_rmse = float(rmse(actual, preds))
-    print(f"  {name}: MAE={split_mae:.4f}  RMSE={split_rmse:.4f}")
-    return split_mae, split_rmse, preds
+    return {
+        "mape": float(darts_mape(actual, preds)),
+        "mae":  float(mae(actual, preds)),
+        "rmse": float(rmse(actual, preds)),
+    }
+
+
+def _copy_loss_csv(work_dir: str, dest_dir: str) -> None:
+    """Copy CSVLogger metrics.csv to dest_dir for dashboard display."""
+    import shutil
+    src = Path(work_dir) / "logs" / "metrics.csv"
+    if src.exists():
+        dest = Path(dest_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src, dest / "metrics.csv")
 
 
 # ---------------------------------------------------------------------------
@@ -170,20 +204,12 @@ def evaluate_split(model, target, covariates, start, name):
 # ---------------------------------------------------------------------------
 
 def write_training_predictions(engine, df, preds_series, split, model_version):
-    """
-    Write out-of-sample predictions to training_predictions table.
-
-    split: 'val' or 'test'
-    df: full dataset DataFrame with 'date' and 'fsi_value' columns (for fsi_actual lookup)
-    """
     is_pg = not engine.url.drivername.startswith("sqlite")
-
     preds_df = preds_series.to_dataframe().reset_index()
     preds_df.columns = ["time", "fsi_pred"]
     preds_df["time"] = pd.to_datetime(preds_df["time"])
     preds_df = preds_df.dropna(subset=["fsi_pred"])
 
-    # Build date -> fsi_actual lookup
     actual_lookup = {
         row["date"].strftime("%Y-%m-%d"): float(row["fsi_value"])
         for _, row in df.iterrows()
@@ -191,34 +217,65 @@ def write_training_predictions(engine, df, preds_series, split, model_version):
 
     with engine.begin() as conn:
         for _, row in preds_df.iterrows():
-            date_str = row["time"].strftime("%Y-%m-%d")
-            pred_val = float(row["fsi_pred"])
+            date_str   = row["time"].strftime("%Y-%m-%d")
+            pred_val   = float(row["fsi_pred"])
             actual_val = actual_lookup.get(date_str)
             if is_pg:
                 sql = text(
-                    """
-                    INSERT INTO training_predictions (date, fsi_actual, fsi_pred, split, model_version)
-                    VALUES (:date, :actual, :pred, :split, :version)
-                    ON CONFLICT (date, split) DO UPDATE SET
-                        fsi_actual    = EXCLUDED.fsi_actual,
-                        fsi_pred      = EXCLUDED.fsi_pred,
-                        model_version = EXCLUDED.model_version
-                    """
+                    "INSERT INTO training_predictions "
+                    "(date, fsi_actual, fsi_pred, split, model_version) "
+                    "VALUES (:date, :actual, :pred, :split, :version) "
+                    "ON CONFLICT (date, split) DO UPDATE SET "
+                    "fsi_actual=EXCLUDED.fsi_actual, fsi_pred=EXCLUDED.fsi_pred, "
+                    "model_version=EXCLUDED.model_version"
                 )
             else:
                 sql = text(
-                    """
-                    INSERT OR REPLACE INTO training_predictions
-                        (date, fsi_actual, fsi_pred, split, model_version)
-                    VALUES (:date, :actual, :pred, :split, :version)
-                    """
+                    "INSERT OR REPLACE INTO training_predictions "
+                    "(date, fsi_actual, fsi_pred, split, model_version) "
+                    "VALUES (:date, :actual, :pred, :split, :version)"
+                )
+            conn.execute(sql, {"date": date_str, "actual": actual_val,
+                               "pred": pred_val, "split": split,
+                               "version": model_version})
+
+
+# ---------------------------------------------------------------------------
+# optuna_trials table writer
+# ---------------------------------------------------------------------------
+
+def write_optuna_trials(engine, study_name, trial_results, model_version):
+    is_pg = not engine.url.drivername.startswith("sqlite")
+    with engine.begin() as conn:
+        for res in trial_results:
+            hp_json = json.dumps(res["params"])
+            if is_pg:
+                sql = text(
+                    "INSERT INTO optuna_trials "
+                    "(study_name, trial_number, rank_val, mape_val, mape_test, "
+                    " mae_test, rmse_test, is_production, hyperparams, model_version) "
+                    "VALUES (:study, :tnum, :rank, :mval, :mtest, "
+                    " :maet, :rmset, :isprod, :hp, :ver)"
+                )
+            else:
+                sql = text(
+                    "INSERT INTO optuna_trials "
+                    "(study_name, trial_number, rank_val, mape_val, mape_test, "
+                    " mae_test, rmse_test, is_production, hyperparams, model_version) "
+                    "VALUES (:study, :tnum, :rank, :mval, :mtest, "
+                    " :maet, :rmset, :isprod, :hp, :ver)"
                 )
             conn.execute(sql, {
-                "date":    date_str,
-                "actual":  actual_val,
-                "pred":    pred_val,
-                "split":   split,
-                "version": model_version,
+                "study":  study_name,
+                "tnum":   res["trial_number"],
+                "rank":   res["rank_val"],
+                "mval":   res["mape_val"],
+                "mtest":  res.get("mape_test"),
+                "maet":   res.get("mae_test"),
+                "rmset":  res.get("rmse_test"),
+                "isprod": 1 if res.get("is_production") else 0,
+                "hp":     hp_json,
+                "ver":    model_version,
             })
 
 
@@ -227,121 +284,206 @@ def write_training_predictions(engine, df, preds_series, split, model_version):
 # ---------------------------------------------------------------------------
 
 def main():
+    import optuna
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+
     engine = get_engine()
     print("Loading dataset...")
     df = load_dataset(engine)
     n = len(df)
-    print(f"Loaded {n} samples spanning {df['date'].iloc[0].date()} to {df['date'].iloc[-1].date()}")
+    print(f"Loaded {n} samples: {df['date'].iloc[0].date()} to {df['date'].iloc[-1].date()}")
 
     TRAIN_SIZE = int(n * TRAIN_PCT)
     VAL_SIZE   = int(n * VAL_PCT)
     TEST_SIZE  = n - TRAIN_SIZE - VAL_SIZE
+    print(f"Split: {TRAIN_SIZE} train / {VAL_SIZE} val / {TEST_SIZE} test  (70/15/15%)")
 
-    min_required = INPUT_CHUNK + 1
-    if n < min_required:
-        raise RuntimeError(
-            f"Need at least {min_required} samples with both FSI and embeddings, got {n}."
-        )
+    if n < 5:
+        raise RuntimeError(f"Need at least 5 samples, got {n}.")
 
     target     = build_target_series(df)
     covariates = build_covariate_series(df)
 
-    # Temporal split by position
     target_train = target[:TRAIN_SIZE]
     target_val   = target[:TRAIN_SIZE + VAL_SIZE]
     target_test  = target
     cov_full     = covariates
 
-    print(f"Split: {TRAIN_SIZE} train / {VAL_SIZE} val / {TEST_SIZE} test  (70/15/15%)")
-
-    # Build and train model
     Path(ARTIFACTS_DIR).mkdir(parents=True, exist_ok=True)
-    model = TiDEModel(
-        input_chunk_length=INPUT_CHUNK,
-        output_chunk_length=OUTPUT_CHUNK,
-        num_encoder_layers=1,
-        num_decoder_layers=1,
-        decoder_output_dim=8,
-        hidden_size=32,
-        temporal_width_past=4,
-        temporal_width_future=4,
-        use_layer_norm=True,
-        dropout=0.1,
-        n_epochs=500,
-        batch_size=4,
-        optimizer_kwargs={"lr": 5e-4},
-        model_name="tide_bapro",
-        work_dir=ARTIFACTS_DIR,
-        save_checkpoints=True,
-        force_reset=True,
-        pl_trainer_kwargs={"enable_progress_bar": True},
-    )
+    trials_dir = Path(ARTIFACTS_DIR) / "optuna_trials"
+    trials_dir.mkdir(parents=True, exist_ok=True)
 
-    print("Training TiDE model...")
-    model.fit(
-        series=target_train,
-        past_covariates=cov_full[:TRAIN_SIZE],
-        future_covariates=cov_full[:TRAIN_SIZE],
-        val_series=target_val,
-        val_past_covariates=cov_full,
-        val_future_covariates=cov_full,
+    # Capture val preds per trial (to avoid retraining later)
+    _trial_val_preds: dict[int, object] = {}
+    _trial_params:    dict[int, dict]   = {}
+
+    # ── Optuna study ─────────────────────────────────────────────────────────
+    def objective(trial):
+        input_chunk = trial.suggest_categorical(
+            "input_chunk_length", [2, 5, min(10, TRAIN_SIZE - 2)]
+        )
+        # Guard: input_chunk must leave room for historical_forecasts on TRAIN
+        if TRAIN_SIZE <= input_chunk + 1:
+            raise optuna.TrialPruned()
+
+        params = {
+            "input_chunk_length": input_chunk,
+            "hidden_size":        trial.suggest_categorical("hidden_size", [32, 64, 128]),
+            "num_encoder_layers": trial.suggest_int("num_encoder_layers", 1, 2),
+            "num_decoder_layers": trial.suggest_int("num_decoder_layers", 1, 2),
+            "dropout":            trial.suggest_float("dropout", 0.05, 0.3),
+            "lr":                 trial.suggest_float("lr", 1e-4, 1e-2, log=True),
+            "n_epochs":           trial.suggest_categorical("n_epochs", [100, 300, 500]),
+            "batch_size":         trial.suggest_categorical("batch_size", [4, 8, 16]),
+            "decoder_output_dim": 8,
+        }
+        work = str(trials_dir / f"trial_{trial.number}")
+        Path(work).mkdir(parents=True, exist_ok=True)
+        model = _build_model(params, work, f"tide_trial_{trial.number}")
+        model.fit(
+            series=target_train,
+            past_covariates=cov_full[:TRAIN_SIZE],
+            future_covariates=cov_full[:TRAIN_SIZE],
+            val_series=target_val,
+            val_past_covariates=cov_full,
+            val_future_covariates=cov_full,
+            verbose=False,
+        )
+        val_preds = _historical_forecasts(
+            model, target_val, cov_full[:TRAIN_SIZE + VAL_SIZE], TRAIN_SIZE
+        )
+        metrics = _eval_metrics(target_val, val_preds)
+        _trial_val_preds[trial.number] = val_preds
+        _trial_params[trial.number]    = params
+        print(f"  Trial {trial.number}: MAPE_val={metrics['mape']:.4f}")
+        return metrics["mape"]
+
+    print(f"Running Optuna study ({OPTUNA_N_TRIALS} trials)...")
+    study = optuna.create_study(
+        direction="minimize",
+        study_name=STUDY_NAME,
+        storage=OPTUNA_DB_URL,
+        load_if_exists=True,
+    )
+    study.optimize(objective, n_trials=OPTUNA_N_TRIALS, show_progress_bar=False)
+
+    # ── Select top-K trials ──────────────────────────────────────────────────
+    completed = [t for t in study.trials if t.value is not None]
+    completed.sort(key=lambda t: t.value)
+    top_trials = completed[:OPTUNA_TOP_K]
+    print(f"Top {len(top_trials)} trials selected for test evaluation:")
+    for rank, t in enumerate(top_trials, 1):
+        print(f"  Rank {rank}: trial {t.number}  MAPE_val={t.value:.4f}")
+
+    # ── Evaluate top-K on TEST ───────────────────────────────────────────────
+    eval_results = []
+    for rank, trial in enumerate(top_trials, start=1):
+        params = _trial_params.get(trial.number, trial.params)
+        work = str(trials_dir / f"rank_{rank}_eval")
+        Path(work).mkdir(parents=True, exist_ok=True)
+
+        print(f"  Evaluating rank {rank} on TEST (retrain on TRAIN+VAL)...")
+        model_eval = _build_model(params, work, f"tide_eval_rank{rank}")
+        model_eval.fit(
+            series=target_val,  # = target[:TRAIN_SIZE + VAL_SIZE]
+            past_covariates=cov_full[:TRAIN_SIZE + VAL_SIZE],
+            future_covariates=cov_full[:TRAIN_SIZE + VAL_SIZE],
+            val_series=target_test,
+            val_past_covariates=cov_full,
+            val_future_covariates=cov_full,
+            verbose=False,
+        )
+        test_preds = _historical_forecasts(
+            model_eval, target_test, cov_full, TRAIN_SIZE + VAL_SIZE
+        )
+        test_metrics = _eval_metrics(target_test, test_preds)
+        print(
+            f"    MAPE_test={test_metrics['mape']:.4f}  "
+            f"MAE={test_metrics['mae']:.4f}  "
+            f"RMSE={test_metrics['rmse']:.4f}"
+        )
+
+        # Copy loss CSV for dashboard
+        dest = str(Path(ARTIFACTS_DIR) / f"trial_{rank}")
+        _copy_loss_csv(work, dest)
+
+        eval_results.append({
+            "rank_val":     rank,
+            "trial_number": trial.number,
+            "params":       params,
+            "mape_val":     trial.value,
+            "mape_test":    test_metrics["mape"],
+            "mae_test":     test_metrics["mae"],
+            "rmse_test":    test_metrics["rmse"],
+            "model_eval":   model_eval,
+            "val_preds":    _trial_val_preds.get(trial.number),
+            "test_preds":   test_preds,
+            "is_production": False,
+        })
+
+    # ── Best by MAPE_test ────────────────────────────────────────────────────
+    best = min(eval_results, key=lambda x: x["mape_test"])
+    best["is_production"] = True
+    best_params = best["params"]
+    print(f"Production model: trial {best['trial_number']}  MAPE_test={best['mape_test']:.4f}")
+
+    # ── Train production model on full dataset ───────────────────────────────
+    prod_work = str(Path(ARTIFACTS_DIR) / "prod")
+    Path(prod_work).mkdir(parents=True, exist_ok=True)
+    print("Training production model on full dataset (TRAIN+VAL+TEST)...")
+    model_prod = _build_model(best_params, prod_work, "tide_bapro", progress=True)
+    model_prod.fit(
+        series=target,
+        past_covariates=cov_full,
+        future_covariates=cov_full,
         verbose=True,
     )
+    model_prod.save(TIDE_MODEL_PATH)
+    print(f"Production model saved: {TIDE_MODEL_PATH}")
 
-    model.save(TIDE_MODEL_PATH)
-    print(f"Model saved: {TIDE_MODEL_PATH}")
-
-    # Evaluate splits and capture out-of-sample predictions
-    print("Evaluating splits...")
-    train_mae_val, train_rmse_val, _ = evaluate_split(
-        model, target_train, cov_full[:TRAIN_SIZE], INPUT_CHUNK, "Train"
-    )
-    val_mae_val, val_rmse_val, val_preds = evaluate_split(
-        model, target_val, cov_full[:TRAIN_SIZE + VAL_SIZE], TRAIN_SIZE, "Val"
-    )
-    test_mae_val, test_rmse_val, test_preds = evaluate_split(
-        model, target_test, cov_full, TRAIN_SIZE + VAL_SIZE, "Test"
-    )
-
+    # ── Write training predictions (out-of-sample) ───────────────────────────
     model_version = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
-    tide_params = {
-        "input_chunk_length": INPUT_CHUNK,
-        "output_chunk_length": OUTPUT_CHUNK,
-        "num_encoder_layers": 1,
-        "num_decoder_layers": 1,
-        "decoder_output_dim": 8,
-        "hidden_size": 32,
-        "temporal_width_past": 4,
-        "temporal_width_future": 4,
-        "use_layer_norm": True,
-        "dropout": 0.1,
-        "n_epochs": 500,
-        "batch_size": 4,
-        "lr": 5e-4,
-    }
-    metadata = {
-        "model_version": model_version,
-        "train_samples": TRAIN_SIZE,
-        "val_samples": VAL_SIZE,
-        "test_samples": TEST_SIZE,
-        "train_mae": train_mae_val,
-        "train_rmse": train_rmse_val,
-        "val_mae": val_mae_val,
-        "val_rmse": val_rmse_val,
-        "test_mae": test_mae_val,
-        "test_rmse": test_rmse_val,
-        "tide_params": tide_params,
-    }
+    if best["val_preds"] is not None:
+        write_training_predictions(engine, df, best["val_preds"], "val", model_version)
+    write_training_predictions(engine, df, best["test_preds"], "test", model_version)
+    print(f"Training predictions written. Version: {model_version}")
 
+    # ── Write Optuna trial results to DB ─────────────────────────────────────
+    write_optuna_trials(engine, STUDY_NAME, eval_results, model_version)
+    print(f"Optuna trial results written to DB ({len(eval_results)} rows)")
+
+    # ── Save metadata ─────────────────────────────────────────────────────────
+    metadata = {
+        "model_version":   model_version,
+        "train_samples":   TRAIN_SIZE,
+        "val_samples":     VAL_SIZE,
+        "test_samples":    TEST_SIZE,
+        # Primary metrics (MAPE)
+        "mape_val_best":   best["mape_val"],
+        "mape_test_prod":  best["mape_test"],
+        # Secondary metrics
+        "mae_test_prod":   best["mae_test"],
+        "rmse_test":       best["rmse_test"],
+        # Legacy key for CI computation in dashboard
+        "test_rmse":       best["rmse_test"],
+        # Optuna
+        "optuna_n_trials": OPTUNA_N_TRIALS,
+        "optuna_top_k":    OPTUNA_TOP_K,
+        "best_trial":      best["trial_number"],
+        "best_params":     best_params,
+        # All finalist results
+        "eval_results": [
+            {k: v for k, v in r.items()
+             if k not in ("model_eval", "val_preds", "test_preds")}
+            for r in eval_results
+        ],
+    }
     meta_path = Path(ARTIFACTS_DIR) / "metadata.json"
     with open(meta_path, "w") as f:
         json.dump(metadata, f, indent=2)
     print(f"Metadata saved: {meta_path}")
-
-    write_training_predictions(engine, df, val_preds, "val", model_version)
-    write_training_predictions(engine, df, test_preds, "test", model_version)
-    print(f"Wrote {len(val_preds)} val + {len(test_preds)} test predictions to DB. Version: {model_version}")
+    print(f"Done. MAPE_val_best={best['mape_val']:.4f}  MAPE_test_prod={best['mape_test']:.4f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **3 Optuna trials** on TRAIN set (minimises MAPE_val); top-2 advance to test
- **2 finalists** retrained on TRAIN+VAL, evaluated on TEST; best MAPE_test wins
- **Production model** retrained on full TRAIN+VAL+TEST dataset
- **Loss curves** saved via CSVLogger to `artifacts/trial_{rank}/metrics.csv`
- **Val/test predictions** (out-of-sample only) written to `training_predictions`
- **Optuna trial results** written to `optuna_trials` table with hyperparams, MAPE_val, MAPE_test, is_production flag
- **metadata.json** updated: `mape_val_best`, `mape_test_prod`, `best_params`; legacy `test_rmse` preserved for CI computation

### Search space
| Param | Values |
|---|---|
| `input_chunk_length` | [2, 5, 10] |
| `hidden_size` | [32, 64, 128] |
| `num_encoder_layers` | [1, 2] |
| `num_decoder_layers` | [1, 2] |
| `dropout` | [0.05, 0.30] |
| `lr` | [1e-4, 1e-2] log |
| `n_epochs` | [100, 300, 500] |
| `batch_size` | [4, 8, 16] |

Closes #32

## Test plan
- [ ] `docker compose run --rm app python training/train.py` completes without error
- [ ] `optuna_trials` table has 2 rows; `is_production=true` on one
- [ ] `training_predictions` has val + test rows after run
- [ ] `metadata.json` contains `mape_val_best`, `mape_test_prod`, `best_params`
- [ ] `artifacts/trial_1/metrics.csv` and `trial_2/metrics.csv` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)