### PR TITLE
feat(dashboard): auto-load daily score from DB on Predicciones tab

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -391,44 +391,8 @@ def _predict_layout():
         # --- FSI history chart with range selector ---
         dcc.Graph(id="fsi-history-chart", style={"height": "380px"}),
 
-        # --- Score section (DASH-04 will replace the textarea below) ---
+        # --- Daily score (auto-loaded from daily_predictions) ---
         html.Div(id="predict-output", style={"marginTop": "24px"}),
-
-        # --- Legacy: textbox + button (removed in DASH-04) ---
-        html.H4("Score manual (temporal)", style={"color": "#8b949e", "marginTop": "24px",
-                                                   "fontSize": "13px"}),
-        dcc.Textarea(
-            id="new-doc-text",
-            placeholder="Paste the document text here…",
-            style={
-                "width": "100%",
-                "height": "200px",
-                "backgroundColor": "#161b22",
-                "color": "#e6edf3",
-                "border": "1px solid #30363d",
-                "borderRadius": "6px",
-                "padding": "12px",
-                "fontSize": "13px",
-                "resize": "vertical",
-                "boxSizing": "border-box",
-            },
-        ),
-        html.Button(
-            "Score Document",
-            id="score-btn",
-            n_clicks=0,
-            style={
-                "marginTop": "12px",
-                "padding": "10px 24px",
-                "backgroundColor": "#388bfd",
-                "color": "white",
-                "border": "none",
-                "borderRadius": "6px",
-                "cursor": "pointer",
-                "fontSize": "14px",
-            },
-        ),
-        html.Div(id="score-output-legacy", style={"marginTop": "24px"}),
     ])
 
 
@@ -1124,204 +1088,101 @@ def render_fsi_history_chart(tab):
     return fig
 
 
-@app.callback(
-    Output("score-output-legacy", "children"),
-    Input("score-btn", "n_clicks"),
-    State("new-doc-text", "value"),
-    prevent_initial_call=True,
-)
-def score_new_document(n_clicks, text):
-    if not text or not text.strip():
-        return html.P("Please paste a document first.", style={"color": "#f78166"})
-
-    tide_model, metadata = load_artifacts()
-    if tide_model is None:
-        return html.P(
-            "TiDE model not found. Run training/train.py first.",
-            style={"color": "#f78166"},
-        )
-
-    try:
-        import json as _json
-        import numpy as _np
-        import pandas as _pd
-        from collections import defaultdict
-        from darts import TimeSeries as _TS
-        from sqlalchemy import text as _text
-
-        # Embed new article
-        st_model = get_st_model()
-        new_emb = st_model.encode([text], convert_to_numpy=True)[0].astype(_np.float32)
-        dim = len(new_emb)
-
-        engine = get_db_engine()
-        with engine.connect() as conn:
-            # Last 15 known FSI values (ascending order)
-            fsi_rows = list(reversed(conn.execute(
-                _text("SELECT date, fsi_value FROM fsi_target ORDER BY date DESC LIMIT 15")
-            ).fetchall()))
-            if not fsi_rows:
-                return html.P("No FSI data in DB.", style={"color": "#f78166"})
-
-            last_fsi_date = _pd.Timestamp(str(fsi_rows[-1][0])[:10])
-            fetch_start  = _pd.Timestamp(str(fsi_rows[0][0])[:10])
-
-            # Today = last business day
-            today = _pd.Timestamp.now().normalize()
-            if today.weekday() >= 5:
-                today = today - _pd.tseries.offsets.BDay(1)
-
-            # n = gap: business days from last_fsi_date (excl) to today (incl)
-            bridge_range = _pd.bdate_range(
-                last_fsi_date + _pd.tseries.offsets.BDay(1), today
-            )
-            n = max(len(bridge_range), 1)
-
-            # Article embeddings covering FSI period + bridge days
-            emb_rows = conn.execute(
-                _text("""
-                    SELECT a.date, ae.embedding
-                    FROM articles a
-                    JOIN article_embeddings ae ON ae.id = a.id
-                    WHERE a.date >= :start
-                    ORDER BY a.date ASC
-                """),
-                {"start": fetch_start.strftime("%Y-%m-%d")},
-            ).fetchall()
-
-        # Build FSI target series — ends at last_fsi_date, no gap padding
-        fsi_dates = [_pd.Timestamp(str(r[0])[:10]) for r in fsi_rows]
-        fsi_vals  = [float(r[1]) for r in fsi_rows]
-        fsi_df = _pd.DataFrame(
-            {"fsi_value": fsi_vals}, index=_pd.DatetimeIndex(fsi_dates)
-        )
-        target_series = _TS.from_dataframe(fsi_df, fill_missing_dates=True, freq="B")
-
-        # Collect embeddings by date from DB
-        date_embs = defaultdict(list)
-        for r in emb_rows:
-            d = _pd.Timestamp(str(r[0])[:10])
-            raw = r[1]
-            vec = _np.array(
-                _json.loads(raw) if isinstance(raw, str) else list(raw),
-                dtype=_np.float32,
-            )
-            date_embs[d].append(vec)
-
-        # Merge new article into today's embedding pool
-        date_embs[today].append(new_emb)
-
-        # Build covariate series covering FSI dates + bridge days + today + 1 extra
-        # (past_covariates must extend n+1 steps beyond target end for n > output_chunk_length)
-        cov_end = today + _pd.tseries.offsets.BDay(1)
-        all_cov_dates = sorted(
-            set(_pd.bdate_range(fetch_start, cov_end).tolist())
-        )
-        zero_vec = _np.zeros(dim, dtype=_np.float32)
-        cov_mat = _np.stack([
-            _np.mean(date_embs[d], axis=0) if date_embs[d] else zero_vec
-            for d in all_cov_dates
-        ])
-        cov_df = _pd.DataFrame(
-            cov_mat,
-            index=_pd.DatetimeIndex(all_cov_dates),
-            columns=[f"emb_{i}" for i in range(dim)],
-        )
-        cov_raw = _TS.from_dataframe(cov_df, fill_missing_dates=True, freq="B")
-        cov_series = _TS.from_dataframe(
-            cov_raw.to_dataframe().fillna(0.0), freq="B"
-        )
-
-        # Predict: n steps to reach today
-        pred = tide_model.predict(
-            n=n,
-            series=target_series,
-            past_covariates=cov_series,
-            future_covariates=cov_series,
-            num_samples=1,
-            show_warnings=False,
-        )
-        score = float(pred.values()[-1, 0])
-
-        # 95% CI from test RMSE (Gaussian approximation: score ± 1.96 * test_rmse)
-        test_rmse = (metadata or {}).get("test_rmse", 0.5)
-        lo = score - 1.96 * test_rmse
-        hi = score + 1.96 * test_rmse
-
-    except Exception as exc:
-        return html.P(f"Error: {exc}", style={"color": "#f78166"})
-
-    # Gauge chart
-    # Thin CI markers on the arc (width = 1.4% of gauge range)
+def _build_gauge(score, lo, hi, pred_date):
+    """Build the stress score gauge with 95% CI markers."""
     eps = 0.05
-    gauge = go.Figure(
-        go.Indicator(
-            mode="gauge+number",
-            value=score,
-            title={"text": "Stress Score", "font": {"color": "#e6edf3"}},
-            number={"font": {"color": "#e6edf3"}},
-            gauge={
-                "axis": {"range": [-3, 4], "tickcolor": "#8b949e"},
-                "bar": {"color": "#388bfd"},
-                "bgcolor": "#161b22",
-                "bordercolor": "#30363d",
-                "steps": [
-                    {"range": [-3, -1], "color": "#1a7f37"},
-                    {"range": [-1, 1], "color": "#9e6a03"},
-                    {"range": [1, 2.5], "color": "#bc4c00"},
-                    {"range": [2.5, 4], "color": "#a40e26"},
-                    {"range": [lo - eps, lo + eps], "color": "#e6edf3"},
-                    {"range": [hi - eps, hi + eps], "color": "#e6edf3"},
-                ],
-                "threshold": {
-                    "line": {"color": "#f78166", "width": 3},
-                    "thickness": 0.75,
-                    "value": score,
-                },
-            },
-        )
-    )
+    gauge = go.Figure(go.Indicator(
+        mode="gauge+number",
+        value=score,
+        title={"text": f"Score al {pred_date}", "font": {"color": "#e6edf3", "size": 13}},
+        number={"font": {"color": "#e6edf3"}},
+        gauge={
+            "axis": {"range": [-3, 4], "tickcolor": "#8b949e"},
+            "bar": {"color": "#388bfd"},
+            "bgcolor": "#161b22",
+            "bordercolor": "#30363d",
+            "steps": [
+                {"range": [-3, -1],  "color": "#1a7f37"},
+                {"range": [-1,  1],  "color": "#9e6a03"},
+                {"range": [ 1,  2.5],"color": "#bc4c00"},
+                {"range": [ 2.5, 4], "color": "#a40e26"},
+                {"range": [lo - eps, lo + eps], "color": "#e6edf3"},
+                {"range": [hi - eps, hi + eps], "color": "#e6edf3"},
+            ],
+            "threshold": {"line": {"color": "#f78166", "width": 3},
+                          "thickness": 0.75, "value": score},
+        },
+    ))
     gauge.update_layout(
-        paper_bgcolor="#161b22",
-        font_color="#e6edf3",
-        height=300,
-        margin={"t": 40, "b": 20, "l": 40, "r": 40},
+        paper_bgcolor="#161b22", font_color="#e6edf3",
+        height=300, margin={"t": 48, "b": 20, "l": 40, "r": 40},
     )
     gauge.add_annotation(
         text=f"95% CI: [{lo:.2f} \u2014 {hi:.2f}]",
-        x=0.5, y=0.05,
-        showarrow=False,
+        x=0.5, y=0.05, showarrow=False,
         font={"size": 12, "color": "#8b949e"},
         xref="paper", yref="paper",
     )
-
-    # Interpretation
     if score >= 2.5:
-        label, color = "HIGH STRESS", "#a40e26"
+        label, bg = "ALTO ESTRES",     "#a40e26"
     elif score >= 1.0:
-        label, color = "ELEVATED STRESS", "#bc4c00"
+        label, bg = "ESTRES ELEVADO",  "#bc4c00"
     elif score >= -1.0:
-        label, color = "NEUTRAL", "#9e6a03"
+        label, bg = "NEUTRAL",         "#9e6a03"
     else:
-        label, color = "CALM — CARRY CONDITIONS", "#1a7f37"
+        label, bg = "CALMA",           "#1a7f37"
 
-    return html.Div(
-        children=[
-            html.Div(
-                style={
-                    "backgroundColor": color,
-                    "color": "white",
-                    "padding": "8px 20px",
-                    "borderRadius": "6px",
-                    "display": "inline-block",
-                    "fontWeight": "bold",
-                    "marginBottom": "16px",
-                },
-                children=f"{label} ({score:.3f})  95% CI [{lo:.2f} \u2014 {hi:.2f}]",
+    return html.Div([
+        html.Div(
+            f"{label}  ({score:.3f})  IC 95% [{lo:.2f} \u2014 {hi:.2f}]",
+            style={"backgroundColor": bg, "color": "white",
+                   "padding": "8px 20px", "borderRadius": "6px",
+                   "display": "inline-block", "fontWeight": "bold",
+                   "marginBottom": "16px", "fontSize": "14px"},
+        ),
+        dcc.Graph(figure=gauge, style={"height": "300px"}),
+    ])
+
+
+@app.callback(
+    Output("predict-output", "children"),
+    Input("tabs", "value"),
+)
+def load_daily_score(tab):
+    if tab != "tab-predict":
+        return ""
+
+    engine = get_db_engine()
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT date, fsi_pred FROM daily_predictions "
+                    "ORDER BY date DESC LIMIT 1"
+                )
+            ).fetchone()
+    except Exception as exc:
+        return html.P(f"Error al leer daily_predictions: {exc}",
+                      style={"color": "#f78166", "fontSize": "13px"})
+
+    if row is None:
+        return html.Div(
+            style=_DARK_PANEL,
+            children=html.P(
+                "Sin predicciones disponibles — ejecutar el pipeline diario.",
+                style={"color": "#8b949e", "fontSize": "13px"},
             ),
-            dcc.Graph(figure=gauge, style={"height": "300px"}),
-        ]
-    )
+        )
+
+    pred_date = str(row[0])[:10]
+    score     = float(row[1])
+
+    _, metadata = load_artifacts()
+    test_rmse   = (metadata or {}).get("test_rmse", 0.5)
+    lo = score - 1.96 * test_rmse
+    hi = score + 1.96 * test_rmse
+
+    return _build_gauge(score, lo, hi, pred_date)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes manual textarea + "Score Document" button from Predicciones tab
- `predict-output` div now auto-loads when the tab is selected via `Input("tabs","value")` trigger
- Reads the most recent row from `daily_predictions` table (written by `daily_pipeline.py`)
- Computes 95% CI band using `test_rmse` from `artifacts/metadata.json`
- Shows friendly empty-state message when no predictions are available
- Stress labels translated to Spanish: CALMA / NEUTRAL / ESTRES ELEVADO / ALTO ESTRES

## Test plan
- [ ] Run full docker pipeline including `daily_pipeline.py`; verify gauge appears on tab load
- [ ] With empty `daily_predictions` table: verify empty-state message is shown
- [ ] With missing `metadata.json`: verify gauge still renders (defaults to CI ± 0.98)
- [ ] Verify FSI history chart still renders correctly above the gauge

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)