### PR TITLE
chore: cleanup legacy tables, fix daily pipeline, add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,111 @@
+# BAPRO Financial Stress System
+
+Argentina sovereign credit stress prediction pipeline. Ingests financial news from GDELT and Argentine media, builds a quantitative Financial Stress Index (FSI) from market data, and trains a Darts TiDE model to predict next-day stress levels.
+
+## Features
+
+- **Real-time ingestion** — GDELT DOC 2.0 (Argentina filter) + RSS from Ambito, Cronista, Infobae
+- **FSI ground truth** — PCA of ^MERV volatility, ARGT sovereign spread, ARS/USD FX, EMB
+- **TiDE forecasting** — 384-dim sentence-transformer embeddings as covariates
+- **Optuna tuning** — automated hyperparameter search with trial history stored in DB
+- **Dash dashboard** — historical FSI chart, training fit, daily prediction gauge
+- **Daily automation** — GitHub Actions cron Mon-Fri 06:00 UTC
+
+## Quick start (Docker)
+
+```bash
+git clone https://github.com/igalkej/bapro_stress.git
+cd bapro_stress
+
+# 1. Build images and start database
+docker compose build && docker compose up -d postgres
+
+# 2. Build FSI target from market data
+docker compose run --rm app python src/data/build_fsi_target.py \
+    --start 2025-11-01 --end 2026-02-24
+
+# 3. Seed FSI and ingest historical articles
+docker compose run --rm app python db/seed_fsi.py
+docker compose run --rm app python src/ingestion/historical_backfill.py \
+    --date-from 2025-11-01 --date-to 2026-02-24
+
+# 4. Embed articles and train model
+docker compose run --rm app python training/embed.py
+docker compose run --rm app python training/train.py
+
+# 5. Run today's prediction and start dashboard
+docker compose run --rm app python src/ingestion/daily_pipeline.py
+docker compose up -d dashboard
+```
+
+Dashboard → http://localhost:8050
+pgAdmin → http://localhost:5050 (admin@bapro.com / admin)
+
+## Dashboard tabs
+
+| Tab | Contents |
+|-----|---------|
+| **Entrenamiento** | FSI historical series + out-of-sample val/test fit + model metrics |
+| **Predicciones** | Latest daily stress score gauge with 95% CI, prediction history chart |
+
+## Repository structure
+
+```
+bapro_stress/
+├── config.py                        # Centralised constants and paths
+├── db/
+│   ├── connection.py                # get_engine() — SQLite auto-schema
+│   ├── schema.sql                   # PostgreSQL schema
+│   └── seed_fsi.py                  # Load fsi_target.csv into DB
+├── src/
+│   ├── data/
+│   │   └── build_fsi_target.py      # Compute FSI via yfinance + PCA
+│   └── ingestion/
+│       ├── gdelt_ingest.py          # GDELT DOC 2.0 fetcher
+│       ├── rss_scraper.py           # RSS scraper (Ambito/Cronista/Infobae)
+│       ├── daily_pipeline.py        # Daily ingest + predict orchestrator
+│       └── historical_backfill.py   # One-time historical article download
+├── training/
+│   ├── embed.py                     # Encode articles → article_embeddings
+│   └── train.py                     # TiDE training + Optuna search
+├── prediction/
+│   └── predict.py                   # CLI: score FSI for a given date
+├── dashboard/
+│   └── app.py                       # Dash application
+├── notebooks/
+│   └── 01_eda_corpus_real.ipynb     # Exploratory data analysis
+├── docs/
+│   └── plan.md                      # Architecture and pipeline docs
+├── .github/workflows/
+│   └── daily_pipeline.yml           # GitHub Actions cron
+└── docker-compose.yml
+```
+
+## Database schema
+
+Active tables:
+
+| Table | Description |
+|-------|-------------|
+| `articles` | News articles (headline, source, URL, GDELT tone) |
+| `article_embeddings` | 384-dim sentence-transformer embeddings |
+| `fsi_target` | Daily FSI value (PCA z-score) |
+| `fsi_components` | Normalised component values |
+| `training_predictions` | Out-of-sample val/test predictions from training |
+| `daily_predictions` | Forward predictions from daily pipeline |
+| `optuna_trials` | Hyperparameter search trial history |
+
+## ML details
+
+- **Model**: TiDE (Temporal Identity Encoder) — Darts 0.41.0
+- **Input**: 2 business days look-back; 1 day ahead
+- **Covariates**: mean-pooled 384-dim article embeddings (past + future); zero vector on days without articles
+- **Uncertainty**: 95% CI from test-set RMSE
+- **Artifact**: `artifacts/tide_model.pt`
+
+## Requirements
+
+- Docker + Docker Compose
+- Python 3.11 (local dev)
+
+See `requirements.txt` for Python dependencies.

--- a/db/connection.py
+++ b/db/connection.py
@@ -2,38 +2,6 @@ from sqlalchemy import create_engine, text
 from config import DATABASE_URL
 
 _SQLITE_SCHEMA = """
-CREATE TABLE IF NOT EXISTS documents (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    doc_date    TEXT NOT NULL UNIQUE,
-    filename    TEXT NOT NULL,
-    doc_type    TEXT NOT NULL DEFAULT 'bloomberg_wrap',
-    content     TEXT NOT NULL,
-    created_at  TEXT DEFAULT (datetime('now'))
-);
-
-CREATE TABLE IF NOT EXISTS stress_index (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    index_date   TEXT NOT NULL UNIQUE,
-    stress_value REAL NOT NULL,
-    created_at   TEXT DEFAULT (datetime('now'))
-);
-
-CREATE TABLE IF NOT EXISTS embeddings (
-    id               INTEGER PRIMARY KEY AUTOINCREMENT,
-    doc_id           INTEGER REFERENCES documents(id) UNIQUE,
-    embedding_vector TEXT NOT NULL,
-    embedding_model  TEXT DEFAULT 'all-MiniLM-L6-v2',
-    created_at       TEXT DEFAULT (datetime('now'))
-);
-
-CREATE TABLE IF NOT EXISTS predictions (
-    id                INTEGER PRIMARY KEY AUTOINCREMENT,
-    doc_id            INTEGER REFERENCES documents(id),
-    stress_score_pred REAL NOT NULL,
-    model_version     TEXT,
-    predicted_at      TEXT DEFAULT (datetime('now'))
-);
-
 CREATE TABLE IF NOT EXISTS articles (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     date          TEXT NOT NULL,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,36 +1,3 @@
-CREATE TABLE IF NOT EXISTS documents (
-    id          SERIAL PRIMARY KEY,
-    doc_date    DATE         NOT NULL UNIQUE,
-    filename    VARCHAR(255) NOT NULL,
-    doc_type    VARCHAR(50)  NOT NULL DEFAULT 'bloomberg_wrap',
-    content     TEXT         NOT NULL,
-    created_at  TIMESTAMP    DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS stress_index (
-    id           SERIAL PRIMARY KEY,
-    index_date   DATE  NOT NULL UNIQUE,
-    stress_value FLOAT NOT NULL,
-    created_at   TIMESTAMP DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS embeddings (
-    id               SERIAL PRIMARY KEY,
-    doc_id           INTEGER REFERENCES documents(id) UNIQUE,
-    embedding_vector FLOAT[] NOT NULL,
-    embedding_model  VARCHAR(255) DEFAULT 'all-MiniLM-L6-v2',
-    created_at       TIMESTAMP DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS predictions (
-    id                SERIAL PRIMARY KEY,
-    date              DATE NOT NULL,
-    stress_score_pred FLOAT  NOT NULL,
-    model_version     VARCHAR(255),
-    predicted_at      TIMESTAMP DEFAULT NOW(),
-    UNIQUE (date, model_version)
-);
-
 CREATE TABLE IF NOT EXISTS articles (
     id            SERIAL PRIMARY KEY,
     date          DATE         NOT NULL,

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,67 +1,133 @@
-
 # BAPRO Financial Stress System
 
-Argentina sovereign credit stress prediction pipeline — January 2024.
+Argentina sovereign credit stress prediction pipeline.
 
 ## Stack
-- Python 3.11 venv at `.braprostress_venv/`
-- SQLite for local dev, PostgreSQL for Docker
-- sentence-transformers (`all-MiniLM-L6-v2`) → Darts TiDE (input_chunk=5, output_chunk=1)
-- 384-dim document embeddings used as TiDE past covariates
-- Dash dashboard on port 8050
+
+| Layer | Technology |
+|-------|-----------|
+| Language | Python 3.11 |
+| Database | PostgreSQL 16 (Docker) / SQLite (local dev) |
+| Embeddings | `sentence-transformers` — `all-MiniLM-L6-v2` (384 dims) |
+| Forecasting | Darts TiDE (Temporal Identity Encoder) |
+| Hyperparameter search | Optuna |
+| Dashboard | Dash + Plotly on port 8050 |
+| Containerisation | Docker Compose |
+| CI/CD | GitHub Actions (daily cron Mon-Fri 06:00 UTC) |
+
+## Architecture
+
+```
+News sources (GDELT DOC 2.0 + RSS)
+        │
+        ▼
+src/ingestion/  ──► articles + article_embeddings tables
+        │
+        ▼
+src/data/build_fsi_target.py  ──► fsi_target table (PCA of market data)
+        │
+        ▼
+training/train.py (TiDE + Optuna)  ──► artifacts/tide_model.pt
+                                    ──► training_predictions table
+        │
+        ▼
+src/ingestion/daily_pipeline.py  ──► daily_predictions table
+        │
+        ▼
+dashboard/app.py  ──► http://localhost:8050
+```
+
+## FSI Ground Truth
+
+Built from Argentine market data via yfinance + PCA:
+
+| Component | Direction | Proxy |
+|-----------|-----------|-------|
+| ^MERV volatility | + | Local equity stress |
+| ARGT (sovereign bond ETF) | − | Sovereign spread |
+| ARS=X (FX rate) | + | Currency stress |
+| EMB (EM bond ETF) | − | External contagion |
+
+Sign validated vs PASO 2019 (Aug 12, 2019 stress peak).
+
+## ML Model
+
+- **TiDE** (Temporal Identity Encoder) from Darts 0.41.0
+- Input chunk: 2 business days look-back
+- Output chunk: 1 business day ahead
+- Covariates: 384-dim mean-pooled article embeddings per day (past + future)
+- Days without articles: zero vector
+- Hyperparameters: tuned with Optuna (stored in `optuna_trials` table)
+- Train/val/test split: 70/15/15% dynamic
+- Model artifact: `artifacts/tide_model.pt`
+
+## Database Schema (active tables)
+
+| Table | Contents |
+|-------|---------|
+| `articles` | Headline, source, URL, GDELT tone per article |
+| `article_embeddings` | 384-dim embedding per article |
+| `fsi_target` | Daily FSI value (PCA score) |
+| `fsi_components` | Raw normalised component values |
+| `training_predictions` | Val/test out-of-sample TiDE predictions |
+| `daily_predictions` | Forward predictions from daily pipeline |
+| `optuna_trials` | Hyperparameter search results |
+
+## Running with Docker (standard)
+
+```bash
+# 1. Build and start database
+docker compose build && docker compose up -d postgres
+
+# 2. Build FSI target from market data
+docker compose run --rm app python src/data/build_fsi_target.py \
+    --start 2025-11-01 --end 2026-02-24
+
+# 3. Seed FSI into DB
+docker compose run --rm app python db/seed_fsi.py
+
+# 4. Ingest historical articles
+docker compose run --rm app python src/ingestion/historical_backfill.py \
+    --date-from 2025-11-01 --date-to 2026-02-24
+
+# 5. Embed articles
+docker compose run --rm app python training/embed.py
+
+# 6. Train model (with Optuna search)
+docker compose run --rm app python training/train.py
+
+# 7. Run daily prediction
+docker compose run --rm app python src/ingestion/daily_pipeline.py
+
+# 8. Start dashboard
+docker compose up -d dashboard
+# → http://localhost:8050
+```
 
 ## Running locally (no Docker)
 
-Always use the project venv:
-```
-.braprostress_venv/Scripts/python.exe <script>
-```
-
-Pipeline order (run each step once, they are idempotent):
-```
-.braprostress_venv/Scripts/python.exe db/seed.py
+```bash
+.braprostress_venv/Scripts/python.exe src/data/build_fsi_target.py --start ... --end ...
+.braprostress_venv/Scripts/python.exe db/seed_fsi.py
+.braprostress_venv/Scripts/python.exe src/ingestion/historical_backfill.py --date-from ... --date-to ...
 .braprostress_venv/Scripts/python.exe training/embed.py
 .braprostress_venv/Scripts/python.exe training/train.py
+.braprostress_venv/Scripts/python.exe src/ingestion/daily_pipeline.py
 .braprostress_venv/Scripts/python.exe dashboard/app.py
 ```
 
-Dashboard: http://localhost:8050
+## Daily automation
 
-## Running with Docker
+`.github/workflows/daily_pipeline.yml` runs Mon-Fri at 06:00 UTC:
 
-```
-docker compose build && docker compose up -d postgres
-docker compose run --rm app python db/seed.py
-make embed && make train
-make dashboard
-```
+1. Ingest GDELT + RSS for the previous business day
+2. Embed new articles
+3. Run TiDE prediction → write to `daily_predictions`
 
 ## Key conventions
 
 - `config.py` is the single source of truth for constants and paths.
-  - No script should hardcode `/workspace` or absolute paths.
-  - Use `Path(__file__).resolve().parent.parent` for repo-relative imports.
-- SQLite vs PostgreSQL differences are handled in the code:
-  - Vectors: JSON string (SQLite) vs FLOAT[] (PostgreSQL)
-  - Upserts: `INSERT OR IGNORE` (SQLite) vs `ON CONFLICT DO NOTHING` (PostgreSQL)
-  - Deletes: portable `IN (...)` clause, not `= ANY(:ids)`
+- SQLite vs PostgreSQL differences handled in code (vectors, upserts, deletes).
 - Print statements must use ASCII only (Windows terminal is cp1252).
-  No `→`, `…`, `—` or other non-ASCII characters in print() calls.
-- Never commit: `*.db`, `artifacts/*.pkl`, `artifacts/*.json`, `.braprostress_venv/`
-
-## Data
-- 22 business days in January 2024 (Jan 1 excluded — New Year)
-- 3 stress spikes: Jan 5 (~2.91), Jan 11 (~2.64), Jan 17 (~2.83)
-- Post-spike calm/recovery: Jan 22–31 (stress values -1.8 to -0.4)
-- `data/stress_index.csv` has 22 rows matching the 22 `.txt` documents
-
-## File map
-| File | Role |
-|------|------|
-| `config.py` | Centralised constants and paths |
-| `db/connection.py` | `get_engine()` — auto-creates SQLite schema |
-| `db/seed.py` | Load docs + stress index into DB |
-| `training/embed.py` | Encode docs → store embeddings |
-| `training/train.py` | Darts TiDE → save artifacts/tide_model/ + predictions |
-| `prediction/predict.py` | CLI: `--text "..."` or `--file path.txt` |
-| `dashboard/app.py` | Dash UI: historical chart + live prediction tab |
+- Never commit: `*.db`, `artifacts/*.pt`, `.braprostress_venv/`
+- Run app commands via `docker compose exec` or `docker compose run --rm app`.


### PR DESCRIPTION
## Summary

- Dropped legacy DB tables (`documents`, `stress_index`, `embeddings`, `predictions`) from schema and connection auto-DDL
- Rewrote `prediction/predict.py` to use `articles` / `fsi_target` / `article_embeddings` tables
- Fixed 4 bugs in `daily_pipeline.py`:
  - PyTorch 2.6 `weights_only` error → `_load_tide_model()` helper with patch
  - `future_covariates` not passed to `model.predict()` → now passed with 1-day zero-vector extension
  - PostgreSQL `date` → `datetime.date` not accepted by Darts → cast with `pd.to_datetime()`
  - `RuntimeError` when 0 new articles but date already ingested → check existing count and proceed
- Rewrote `docs/plan.md` to reflect current real-data architecture
- Added `README.md` with quickstart, repo structure, DB schema, and ML details
- Closed all 11 completed/deprecated GitHub issues

## Test plan
- [x] Daily prediction for 2026-02-24 ran successfully → FSI -3.22 (CALMA)
- [x] `daily_predictions` table populated
- [x] Dashboard Predicciones tab shows today's score

🤖 Generated with [Claude Code](https://claude.com/claude-code)