### PR TITLE
fix: exclude article-less days from training

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ OFR FSI composite is stored in `fsi_components` as reference but excluded from t
 - **Input**: `input_chunk_length` business days look-back (tuned by Optuna); 1 day ahead output
 - **Gap nowcasting**: `n = business days from last published FSI to target date`; uses real article embeddings for gap days as `future_covariates`
 - **Lag offset**: val/test evaluation starts at `split_boundary + input_chunk_length` to avoid look-back window leaking training observations into held-out sets
-- **Covariates**: mean-pooled 384-dim article embeddings (past + future); zero vector on days without articles
+- **Covariates**: mean-pooled 384-dim article embeddings (past + future); training uses only days with real embeddings — no zero-vector fabrication
+- **Data integrity**: `training/train.py` fails fast with an error log listing specific dates if any business day has no articles, so ingestion gaps are caught before training
 - **Uncertainty**: 95% CI from test-set RMSE
 - **Artifact**: `artifacts/tide_model.pt`
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -74,7 +74,9 @@ Sign validated against PASO 2019 (Aug 12, 2019 stress peak): FSI value on that d
 - Input chunk: tuned by Optuna (candidates: 2, 5, up to min(10, TRAIN_SIZE-2)); output chunk: 1 business day ahead
 - Lag offset: `historical_forecasts` start at `split_boundary + input_chunk_length` for both val and test, so the look-back window never includes observations from the other split (no boundary leakage)
 - Optuna guard: trials where `input_chunk_length >= VAL_SIZE` or `>= TEST_SIZE` are pruned to avoid out-of-bounds errors
-- Covariates: mean-pooled 384-dim article embeddings per day (past + future); zero vector for days without articles
+- Covariates: 384-dim mean-pooled article embeddings per day (past + future); training uses only days with real embeddings — no zero-vector fabrication
+- Data integrity: `train.py` fails fast with an `error` log listing specific dates if any business day has no articles (every business day is expected to have news)
+- Hyperparameters: tuned with Optuna (stored in `optuna_trials` table)
 - Train/val/test split: 70/15/15% dynamic
 - Model artifact: `artifacts/tide_model.pt`
 

--- a/src/ingestion/daily_pipeline.py
+++ b/src/ingestion/daily_pipeline.py
@@ -201,17 +201,12 @@ def _run_tide_prediction(
     ctx = context_df.tail(input_chunk).reset_index(drop=True)
     ctx["date"] = pd.to_datetime(ctx["date"].astype(str).str[:10])
 
-    fsi_raw = TimeSeries.from_dataframe(
+    fsi_series = TimeSeries.from_dataframe(
         ctx[["date", "fsi_value"]].rename(columns={"fsi_value": "value"}),
         time_col="date",
         value_cols=["value"],
         freq="B",
         fill_missing_dates=True,
-    )
-    # Forward-fill any gap days in the context window (business days without
-    # articles that were excluded from context_df but needed for continuity).
-    fsi_series = TimeSeries.from_dataframe(
-        fsi_raw.to_dataframe().ffill().bfill(), freq="B"
     )
 
     emb_dim = len(ctx["embedding"].iloc[0])

--- a/src/ingestion/daily_pipeline.py
+++ b/src/ingestion/daily_pipeline.py
@@ -201,13 +201,17 @@ def _run_tide_prediction(
     ctx = context_df.tail(input_chunk).reset_index(drop=True)
     ctx["date"] = pd.to_datetime(ctx["date"].astype(str).str[:10])
 
-    fsi_series = TimeSeries.from_dataframe(
+    fsi_raw = TimeSeries.from_dataframe(
         ctx[["date", "fsi_value"]].rename(columns={"fsi_value": "value"}),
         time_col="date",
         value_cols=["value"],
         freq="B",
         fill_missing_dates=True,
-        fillna_value=0.0,
+    )
+    # Forward-fill any gap days in the context window (business days without
+    # articles that were excluded from context_df but needed for continuity).
+    fsi_series = TimeSeries.from_dataframe(
+        fsi_raw.to_dataframe().ffill().bfill(), freq="B"
     )
 
     emb_dim = len(ctx["embedding"].iloc[0])

--- a/training/train.py
+++ b/training/train.py
@@ -56,6 +56,8 @@ def load_dataset(engine):
     """
     Join articles + article_embeddings + fsi_target on date.
     Mean-pool embeddings per business day.
+    Only days with real article embeddings are included — days without
+    articles are excluded entirely (no zero-vector fabrication).
     Returns DataFrame: date (datetime), vec (np.array), fsi_value (float).
     """
     with engine.connect() as conn:
@@ -87,16 +89,19 @@ def load_dataset(engine):
         date_vecs.setdefault(date_str, []).append(vec)
 
     mean_vecs = {d: np.mean(vecs, axis=0) for d, vecs in date_vecs.items()}
-    emb_dim   = next(iter(mean_vecs.values())).shape[0] if mean_vecs else 384
-    zero_vec  = np.zeros(emb_dim, dtype=np.float32)
+    fsi_lookup = {str(row[0])[:10]: float(row[1]) for row in fsi_rows}
 
+    # Only include days that have BOTH real FSI and real article embeddings.
+    # Days without articles are excluded — no zero-vector fabrication.
     records = []
-    for row in fsi_rows:
-        date_str = str(row[0])[:10]
+    for date_str, vec in mean_vecs.items():
+        fsi_val = fsi_lookup.get(date_str)
+        if fsi_val is None:
+            continue
         records.append({
             "date":      date_str,
-            "vec":       mean_vecs.get(date_str, zero_vec),
-            "fsi_value": float(row[1]),
+            "vec":       vec,
+            "fsi_value": fsi_val,
         })
 
     if not records:
@@ -112,10 +117,15 @@ def load_dataset(engine):
 # ---------------------------------------------------------------------------
 
 def build_target_series(df):
-    return TimeSeries.from_dataframe(
+    # Build a contiguous business-day series. Since df only contains days with
+    # real articles, fill_missing_dates adds NaN for gap days; ffill carries
+    # the last known FSI forward so TiDE sees a continuous target.
+    ts = TimeSeries.from_dataframe(
         df, time_col="date", value_cols="fsi_value",
         fill_missing_dates=True, freq="B",
     )
+    filled = ts.to_dataframe().ffill().bfill()
+    return TimeSeries.from_dataframe(filled, freq="B")
 
 
 def build_covariate_series(df):

--- a/training/train.py
+++ b/training/train.py
@@ -491,6 +491,17 @@ def main():
         raise RuntimeError(f"Need at least 5 samples, got {n}.")
 
     target     = build_target_series(df)
+    nan_mask = target.to_dataframe().isna().any(axis=1)
+    if nan_mask.any():
+        missing = nan_mask[nan_mask].index.strftime("%Y-%m-%d").tolist()
+        log.error("training_target_has_gaps",
+                  count=len(missing), dates=missing,
+                  note="business days with no articles — check ingestion for these dates")
+        raise RuntimeError(
+            f"FSI target has {len(missing)} business day(s) with no articles: "
+            f"{missing[:5]}{'...' if len(missing) > 5 else ''}. "
+            f"Fix ingestion for those dates before training."
+        )
     covariates = build_covariate_series(df)
 
     target_train = target[:TRAIN_SIZE]

--- a/training/train.py
+++ b/training/train.py
@@ -117,15 +117,10 @@ def load_dataset(engine):
 # ---------------------------------------------------------------------------
 
 def build_target_series(df):
-    # Build a contiguous business-day series. Since df only contains days with
-    # real articles, fill_missing_dates adds NaN for gap days; ffill carries
-    # the last known FSI forward so TiDE sees a continuous target.
-    ts = TimeSeries.from_dataframe(
+    return TimeSeries.from_dataframe(
         df, time_col="date", value_cols="fsi_value",
         fill_missing_dates=True, freq="B",
     )
-    filled = ts.to_dataframe().ffill().bfill()
-    return TimeSeries.from_dataframe(filled, freq="B")
 
 
 def build_covariate_series(df):


### PR DESCRIPTION
## Problema

`load_dataset()` en `train.py` fabricaba vectores cero en memoria para días sin artículos:
```python
"vec": mean_vecs.get(date_str, zero_vec)  # zero_vec para días sin noticias
```
El modelo entrenaba con pares `(zero_embedding, FSI_real)` para esos días — patrón espurio sin correlato real.

Los ceros nunca se guardaban en la DB (`article_embeddings` solo tiene embeddings reales), pero contaminaban el entrenamiento en memoria.

## Solución

`load_dataset()` ahora itera sobre `mean_vecs` (solo días con artículos reales) en lugar de sobre todos los días de `fsi_target`. Días sin artículos son excluidos del dataset — ningún vector cero entra al training.

Como todos los días hábiles tienen noticias, el dataset filtrado cubre todos los días hábiles sin gaps. `build_target_series()` no necesita ningún tipo de interpolación.

Para predicción, los días con noticias pero sin FSI publicado (el "gap" de nowcasting) son manejados por Darts autorregressivamente vía `predict(n=gap_days)` con `output_chunk_length=1` — ya estaba implementado.

## Cambios

- `training/train.py — load_dataset()`: itera sobre `mean_vecs` (article days) en lugar de `fsi_rows` (all days). Días sin artículos excluidos.
- `src/ingestion/daily_pipeline.py — _run_tide_prediction()`: eliminado `fillna_value=0.0` de la serie FSI del contexto (ponía FSI=0 para días sin datos — incorrecto).

## Impacto

Requiere re-entrenamiento del modelo después del merge.