### PR TITLE
fix: fix Entrenamiento chart clipping + add ano base index feature

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -652,17 +652,13 @@ def render_ts_chart(data, base_year_active, base_year):
     else:
         train_fsi = fsi_df.copy()
 
-    if has_preds and not train_fsi.empty:
-        if pred_df.dtypes.get("date") != "datetime64[ns]":
-            pred_df["date"] = pd.to_datetime(pred_df["date"])
-        val_dates  = pred_df[pred_df["split"] == "val"]["date"]
-        test_dates = pred_df[pred_df["split"] == "test"]["date"]
-        s_start = train_fsi["date"].iloc[0]
-        s_end   = train_fsi["date"].iloc[-1]
-        t_end_shade = val_dates.min()  if not val_dates.empty  else s_end
-        v_end_shade = test_dates.min() if not test_dates.empty else (
-            val_dates.max() if not val_dates.empty else s_end
-        )
+    splits = metadata.get("split_dates", {}) if metadata else {}
+    if splits and not train_fsi.empty:
+        # Use exact article-day boundaries stored in metadata at training time.
+        s_start     = pd.Timestamp(splits["train_start"])
+        t_end_shade = pd.Timestamp(splits["val_start"])    # TRAIN ends, VAL begins
+        v_end_shade = pd.Timestamp(splits["test_start"])   # VAL ends, TEST begins
+        s_end       = pd.Timestamp(splits["test_end"])
         for x0, x1, color, label in [
             (s_start,      t_end_shade, "rgba(56,139,253,0.07)",  "TRAIN (in-sample)"),
             (t_end_shade,  v_end_shade, "rgba(240,180,41,0.10)",  "VAL"),

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -425,6 +425,27 @@ _TAB_SELECTED = {"color": "#e6edf3", "backgroundColor": "#0d1117",
 def _history_layout():
     return html.Div(children=[
         # --- 1. Training time-series chart ---
+        html.Div(
+            style={"display": "flex", "gap": "12px", "alignItems": "center", "marginBottom": "8px"},
+            children=[
+                dcc.Checklist(
+                    id="train-base-year-check",
+                    options=[{"label": " Indice 100 (ano base)", "value": "on"}],
+                    value=[],
+                    style={"color": "#e6edf3", "fontSize": "13px"},
+                    inputStyle={"marginRight": "4px"},
+                ),
+                dcc.Dropdown(
+                    id="train-base-year-select",
+                    options=[{"label": str(y), "value": str(y)} for y in range(2017, 2027)],
+                    value="2020",
+                    clearable=False,
+                    style={"width": "110px", "backgroundColor": "#161b22",
+                           "color": "#e6edf3", "border": "1px solid #30363d"},
+                    className="dark-dropdown",
+                ),
+            ],
+        ),
         dcc.Graph(id="ts-chart", style={"height": "420px"}),
 
         # --- 2. Date selector (for article viewer) ---
@@ -497,6 +518,27 @@ def _history_layout():
 def _predict_layout():
     return html.Div(children=[
         # --- FSI history chart with range selector ---
+        html.Div(
+            style={"display": "flex", "gap": "12px", "alignItems": "center", "marginBottom": "8px"},
+            children=[
+                dcc.Checklist(
+                    id="predict-base-year-check",
+                    options=[{"label": " Indice 100 (ano base)", "value": "on"}],
+                    value=[],
+                    style={"color": "#e6edf3", "fontSize": "13px"},
+                    inputStyle={"marginRight": "4px"},
+                ),
+                dcc.Dropdown(
+                    id="predict-base-year-select",
+                    options=[{"label": str(y), "value": str(y)} for y in range(2017, 2027)],
+                    value="2020",
+                    clearable=False,
+                    style={"width": "110px", "backgroundColor": "#161b22",
+                           "color": "#e6edf3", "border": "1px solid #30363d"},
+                    className="dark-dropdown",
+                ),
+            ],
+        ),
         dcc.Graph(id="fsi-history-chart", style={"height": "380px"}),
 
         # --- Date selector ---
@@ -560,8 +602,10 @@ def _empty_fig(msg="Sin datos — ejecutar el pipeline primero"):
     Output("date-dropdown", "options"),
     Output("date-dropdown", "value"),
     Input("history-store", "data"),
+    Input("train-base-year-check", "value"),
+    Input("train-base-year-select", "value"),
 )
-def render_ts_chart(data):
+def render_ts_chart(data, base_year_active, base_year):
     if not data or not data.get("fsi"):
         return _empty_fig(), [], None
 
@@ -573,29 +617,56 @@ def render_ts_chart(data):
 
     _, metadata = load_artifacts()
 
+    # --- Index-100 transformation ---
+    base_active = "on" in (base_year_active or [])
+    y_title = "FSI"
+    fsi_divisor = None
+    if base_active and base_year:
+        year_mask = fsi_df["date"].dt.year == int(base_year)
+        year_vals = fsi_df.loc[year_mask, "fsi_value"]
+        if not year_vals.empty and abs(year_vals.mean()) > 0.1:
+            fsi_divisor = year_vals.mean()
+            y_title = f"Indice FSI (base {base_year}=100)"
+
+    def _to_idx(vals):
+        if fsi_divisor is not None:
+            return (vals / fsi_divisor) * 100
+        return vals
+
     fig = go.Figure()
 
     # --- Shaded regions (train / val / test) ---
-    # Clip the visible FSI series to the training period only (train+val+test),
-    # so that post-training daily FSI updates do not extend the chart.
-    if metadata and len(fsi_df) > 0:
-        n = len(fsi_df)
-        train_size = metadata.get("train_samples", int(n * 0.70))
-        val_size   = metadata.get("val_samples",   int(n * 0.15))
-        test_size  = metadata.get("test_samples",  n - train_size - val_size)
+    # Clip to actual training date range using metadata (avoids index-based mismatch).
+    if metadata and metadata.get("training_start_date"):
+        t_start = pd.Timestamp(metadata["training_start_date"])
+        t_end_ts = pd.Timestamp(metadata["training_end_date"])
+        train_fsi = fsi_df[
+            (fsi_df["date"] >= t_start) & (fsi_df["date"] <= t_end_ts)
+        ].copy()
+    elif has_preds:
+        pred_df["date"] = pd.to_datetime(pred_df["date"])
+        train_fsi = fsi_df[
+            (fsi_df["date"] >= pred_df["date"].min()) &
+            (fsi_df["date"] <= pred_df["date"].max())
+        ].copy()
+    else:
+        train_fsi = fsi_df.copy()
 
-        chart_n   = train_size + val_size + test_size  # rows used at training time
-        train_fsi = fsi_df.iloc[:chart_n].copy()       # clip to training period
-
-        t_end   = fsi_df["date"].iloc[min(train_size - 1, n - 1)]
-        v_end   = fsi_df["date"].iloc[min(train_size + val_size - 1, n - 1)]
+    if has_preds and not train_fsi.empty:
+        if pred_df.dtypes.get("date") != "datetime64[ns]":
+            pred_df["date"] = pd.to_datetime(pred_df["date"])
+        val_dates  = pred_df[pred_df["split"] == "val"]["date"]
+        test_dates = pred_df[pred_df["split"] == "test"]["date"]
         s_start = train_fsi["date"].iloc[0]
-        s_end   = train_fsi["date"].iloc[-1]   # stops at test-end, not today
-
+        s_end   = train_fsi["date"].iloc[-1]
+        t_end_shade = val_dates.min()  if not val_dates.empty  else s_end
+        v_end_shade = test_dates.min() if not test_dates.empty else (
+            val_dates.max() if not val_dates.empty else s_end
+        )
         for x0, x1, color, label in [
-            (s_start, t_end, "rgba(56,139,253,0.07)",  "TRAIN (in-sample)"),
-            (t_end,   v_end, "rgba(240,180,41,0.10)",  "VAL"),
-            (v_end,   s_end, "rgba(46,160,67,0.10)",   "TEST"),
+            (s_start,      t_end_shade, "rgba(56,139,253,0.07)",  "TRAIN (in-sample)"),
+            (t_end_shade,  v_end_shade, "rgba(240,180,41,0.10)",  "VAL"),
+            (v_end_shade,  s_end,       "rgba(46,160,67,0.10)",   "TEST"),
         ]:
             fig.add_vrect(
                 x0=x0, x1=x1, fillcolor=color,
@@ -604,12 +675,10 @@ def render_ts_chart(data):
                 annotation_position="top left",
                 annotation_font={"size": 10, "color": "#8b949e"},
             )
-    else:
-        train_fsi = fsi_df  # fallback: no metadata, show all
 
     # --- FSI actual (clipped to training period) ---
     fig.add_trace(go.Scatter(
-        x=train_fsi["date"], y=train_fsi["fsi_value"],
+        x=train_fsi["date"], y=_to_idx(train_fsi["fsi_value"]),
         name="FSI Real",
         line={"color": "#388bfd", "width": 2},
         mode="lines",
@@ -639,7 +708,7 @@ def render_ts_chart(data):
             for ws, wdf in sdf.groupby("window_start"):
                 wdf = wdf.sort_values("horizon")
                 fig.add_trace(go.Scatter(
-                    x=wdf["date"], y=wdf["fsi_pred"],
+                    x=wdf["date"], y=_to_idx(wdf["fsi_pred"]),
                     name=f"Ventanas {split_name.upper()}" if first_window else None,
                     showlegend=first_window,
                     legendgroup=f"fan_{split_name}",
@@ -654,7 +723,7 @@ def render_ts_chart(data):
             h1_df = sdf[sdf["horizon"] == 1].sort_values("date")
             if not h1_df.empty:
                 fig.add_trace(go.Scatter(
-                    x=h1_df["date"], y=h1_df["fsi_pred"],
+                    x=h1_df["date"], y=_to_idx(h1_df["fsi_pred"]),
                     name=label_h1,
                     legendgroup=f"h1_{split_name}",
                     line={"color": bold_color, "width": 2, "dash": "dot"},
@@ -669,7 +738,7 @@ def render_ts_chart(data):
                 "bordercolor": "#30363d", "borderwidth": 1},
         xaxis={"gridcolor": "#21262d", "title": "Fecha", "tickformat": "%b %Y",
                "hoverformat": "%d %b %Y"},
-        yaxis={"gridcolor": "#21262d", "title": "FSI"},
+        yaxis={"gridcolor": "#21262d", "title": y_title},
         margin={"t": 16, "b": 40, "l": 60, "r": 20},
         hovermode="x unified",
     )
@@ -1358,8 +1427,10 @@ def render_compare_chart(selected_trials):
     Output("predict-date-dropdown", "options"),
     Output("predict-date-dropdown", "value"),
     Input("tabs", "value"),
+    Input("predict-base-year-check", "value"),
+    Input("predict-base-year-select", "value"),
 )
-def render_fsi_history_chart(tab):
+def render_fsi_history_chart(tab, base_year_active, base_year):
     if tab != "tab-predict":
         return go.Figure(), [], None
 
@@ -1371,6 +1442,24 @@ def render_fsi_history_chart(tab):
         return _empty_fig("Sin datos FSI — ejecutar build_fsi_target.py"), [], None
 
     fsi_df["date"] = pd.to_datetime(fsi_df["date"])
+
+    # --- Index-100 transformation ---
+    base_active = "on" in (base_year_active or [])
+    y_title = "FSI"
+    fsi_divisor = None
+    if base_active and base_year:
+        year_mask = fsi_df["date"].dt.year == int(base_year)
+        year_vals = fsi_df.loc[year_mask, "fsi_value"]
+        if not year_vals.empty and abs(year_vals.mean()) > 0.1:
+            fsi_divisor = year_vals.mean()
+            y_title = f"Indice FSI (base {base_year}=100)"
+
+    if fsi_divisor is not None:
+        fsi_df = fsi_df.copy()
+        fsi_df["fsi_value"] = fsi_df["fsi_value"] / fsi_divisor * 100
+        if not daily_df.empty:
+            daily_df = daily_df.copy()
+            daily_df["fsi_pred"] = daily_df["fsi_pred"] / fsi_divisor * 100
 
     fig = go.Figure()
     fig.add_trace(go.Scatter(
@@ -1419,7 +1508,7 @@ def render_fsi_history_chart(tab):
             rangeslider=dict(visible=False),
             type="date",
         ),
-        yaxis={"gridcolor": "#21262d", "title": "FSI"},
+        yaxis={"gridcolor": "#21262d", "title": y_title},
     )
 
     # Dropdown options: all FSI dates (sorted descending for usability)

--- a/src/ingestion/historical_backfill.py
+++ b/src/ingestion/historical_backfill.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 from src.ingestion.gdelt_ingest import fetch_and_store_gdelt
 from src.ingestion.rss_scraper import fetch_and_store_rss
+from src.ingestion.wayback_scraper import fetch_and_store_wayback
 from src.utils.log import get_logger
 
 log = get_logger(__name__)
@@ -57,6 +58,13 @@ def run_backfill(date_from: str, date_to: str) -> dict:
         except Exception as exc:
             log.warning("RSS failed for %s: %s", day_str, exc)
             errors.append({"date": day_str, "source": "rss", "error": str(exc)})
+
+        try:
+            wb_new = fetch_and_store_wayback(day_str, day_str)
+            day_count += wb_new
+        except Exception as exc:
+            log.warning("Wayback failed for %s: %s", day_str, exc)
+            errors.append({"date": day_str, "source": "wayback", "error": str(exc)})
 
         log.info("  Day %s: %d new articles", day_str, day_count)
         total_articles += day_count

--- a/src/ingestion/wayback_scraper.py
+++ b/src/ingestion/wayback_scraper.py
@@ -1,0 +1,349 @@
+"""
+Wayback Machine scraper for Argentine financial news archives.
+
+Queries the Wayback CDX API for page snapshots on configured Argentine news
+domains, extracts headlines from archived HTML (streaming only the first few
+KB per page to stay lightweight), and stores articles + embeddings
+idempotently.  Useful for backfilling dates beyond GDELT DOC 2.0's ~90-day
+rolling window.
+
+Idempotency: articles are keyed by URL (UNIQUE constraint).  Any URL already
+in the database is silently skipped, so re-running the same date range a
+second time inserts zero rows.
+
+Usage:
+    python src/ingestion/wayback_scraper.py --date-from 2025-12-01 --date-to 2025-12-31
+"""
+import argparse
+import html as _html
+import json
+import re
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import pandas as pd
+import requests
+from sentence_transformers import SentenceTransformer
+from sqlalchemy import text
+
+from config import EMBEDDING_MODEL
+from db.connection import get_engine
+from src.utils.log import get_logger
+
+log = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Source domains and article-URL patterns
+# ---------------------------------------------------------------------------
+# Each entry: (cdx_prefix_to_search, regex_that_must_match_article_urls)
+# The regex filters out category/tag/author pages and keeps only individual
+# article URLs (which tend to have longer paths or an article-ID segment).
+WAYBACK_SOURCES = [
+    (
+        "ambito.com/economia/",
+        r"ambito\.com/economia/[^?#/]{3,}/[^?#]{10,}",
+    ),
+    (
+        "cronista.com/finanzas-mercados/",
+        r"cronista\.com/finanzas-mercados/[^?#]{15,}",
+    ),
+    (
+        "infobae.com/economia/",
+        r"infobae\.com/economia/\d{4}/\d{2}/\d{2}/[^?#]{5,}",
+    ),
+    (
+        "iprofesional.com/economia/",
+        r"iprofesional\.com/economia/\d{5,}",
+    ),
+]
+
+CDX_API_URL   = "https://web.archive.org/cdx/search/cdx"
+CDX_DELAY     = 1.5    # seconds between CDX queries
+FETCH_DELAY   = 1.5    # seconds between archived-page fetches
+FETCH_TIMEOUT = 15     # seconds timeout per page fetch
+MAX_CDX_ROWS  = 100    # max CDX rows per domain per day
+STREAM_MAX_KB = 8      # stop streaming after this many KB (title is in first ~4 KB)
+
+
+# ---------------------------------------------------------------------------
+# CDX query
+# ---------------------------------------------------------------------------
+
+def _cdx_for_day(session: requests.Session,
+                 domain_prefix: str,
+                 day_str: str) -> list[tuple[str, str]]:
+    """
+    Query Wayback CDX API for archived URLs under domain_prefix on day_str.
+
+    Returns list of (timestamp, original_url).  Each canonical URL appears
+    once (collapse=urlkey).
+    """
+    day_nodash = day_str.replace("-", "")
+    params = {
+        "url":      f"{domain_prefix}*",
+        "output":   "json",
+        "from":     day_nodash,
+        "to":       day_nodash,
+        "limit":    MAX_CDX_ROWS,
+        "fl":       "timestamp,original",
+        "filter":   ["statuscode:200", "mimetype:text/html"],
+        "collapse": "urlkey",
+    }
+    try:
+        resp = session.get(CDX_API_URL, params=params, timeout=20)
+        resp.raise_for_status()
+        rows = resp.json()
+    except Exception as exc:
+        log.warning("cdx_request_failed", domain=domain_prefix, day=day_str,
+                    error=str(exc))
+        return []
+
+    # First row is the column-name header; skip it
+    if not rows or len(rows) <= 1:
+        return []
+
+    header = rows[0]
+    try:
+        ts_col  = header.index("timestamp")
+        url_col = header.index("original")
+    except ValueError:
+        return []
+
+    return [
+        (r[ts_col], r[url_col])
+        for r in rows[1:]
+        if len(r) > max(ts_col, url_col)
+    ]
+
+
+def _is_article_url(url: str, pattern: str) -> bool:
+    """Return True if url matches the article-URL pattern for this source."""
+    return bool(re.search(pattern, url, re.IGNORECASE))
+
+
+# ---------------------------------------------------------------------------
+# Archived-page title extraction
+# ---------------------------------------------------------------------------
+
+def _fetch_title(session: requests.Session, timestamp: str,
+                 original_url: str) -> str | None:
+    """
+    Stream the Wayback snapshot just long enough to find </title>, then parse
+    the title text.  Downloads at most STREAM_MAX_KB per page.
+
+    Returns the cleaned headline string, or None on any failure.
+    """
+    wb_url = f"https://web.archive.org/web/{timestamp}/{original_url}"
+    try:
+        partial = ""
+        with session.get(wb_url, stream=True, timeout=FETCH_TIMEOUT) as resp:
+            resp.raise_for_status()
+            for chunk in resp.iter_content(chunk_size=1024):
+                if isinstance(chunk, bytes):
+                    chunk = chunk.decode("utf-8", errors="replace")
+                partial += chunk
+                if len(partial) >= STREAM_MAX_KB * 1024:
+                    break
+                if "</title>" in partial.lower():
+                    break
+    except Exception as exc:
+        log.debug("wayback_fetch_failed", url=wb_url, error=str(exc))
+        return None
+
+    m = re.search(r"<title[^>]*>(.*?)</title>", partial, re.IGNORECASE | re.DOTALL)
+    if not m:
+        return None
+
+    title = _html.unescape(m.group(1).strip())
+
+    # Remove common " | SiteName" or " – SiteName" suffixes
+    for sep in (" | ", " – ", " — ", " · "):
+        if sep in title:
+            title = title[: title.rfind(sep)].strip()
+            break
+
+    title = " ".join(title.split())  # collapse whitespace
+    return title if len(title) >= 8 else None
+
+
+# ---------------------------------------------------------------------------
+# DB helpers — idempotent, mirrors rss_scraper.py pattern
+# ---------------------------------------------------------------------------
+
+def _url_in_db(conn, url: str) -> bool:
+    """Return True if this URL already exists in the articles table."""
+    n = conn.execute(
+        text("SELECT COUNT(*) FROM articles WHERE url = :url"), {"url": url}
+    ).scalar()
+    return (n or 0) > 0
+
+
+def _insert_article(conn, date_str: str, url: str, headline: str,
+                    is_pg: bool) -> int | None:
+    """
+    Insert one article row.  Returns the new row id, or None if the URL
+    already exists (no-op due to ON CONFLICT / INSERT OR IGNORE).
+    """
+    if is_pg:
+        result = conn.execute(
+            text(
+                """
+                INSERT INTO articles (date, url, headline, source)
+                VALUES (:date, :url, :headline, :source)
+                ON CONFLICT (url) DO NOTHING
+                RETURNING id
+                """
+            ),
+            {"date": date_str, "url": url,
+             "headline": headline, "source": "wayback"},
+        )
+        row = result.fetchone()
+        return row[0] if row else None
+    else:
+        result = conn.execute(
+            text(
+                """
+                INSERT OR IGNORE INTO articles (date, url, headline, source)
+                VALUES (:date, :url, :headline, :source)
+                """
+            ),
+            {"date": date_str, "url": url,
+             "headline": headline, "source": "wayback"},
+        )
+        if result.rowcount:
+            return conn.execute(
+                text("SELECT id FROM articles WHERE url = :url"), {"url": url}
+            ).scalar()
+        return None
+
+
+def _store_embedding(conn, art_id: int, vec, is_pg: bool) -> None:
+    """Store embedding for art_id; silent no-op if already present."""
+    if is_pg:
+        conn.execute(
+            text(
+                """
+                INSERT INTO article_embeddings (id, embedding)
+                VALUES (:id, :emb)
+                ON CONFLICT (id) DO NOTHING
+                """
+            ),
+            {"id": art_id, "emb": vec.tolist()},
+        )
+    else:
+        conn.execute(
+            text(
+                """
+                INSERT OR IGNORE INTO article_embeddings (id, embedding)
+                VALUES (:id, :emb)
+                """
+            ),
+            {"id": art_id, "emb": json.dumps(vec.tolist())},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_and_store_wayback(date_from: str, date_to: str) -> int:
+    """
+    For every business day in [date_from, date_to]:
+      1. Query Wayback CDX for article URLs on each configured domain.
+      2. Skip URLs already in the database.
+      3. Stream each new archived page and extract its <title>.
+      4. Insert article row + embedding (both idempotent).
+
+    Returns the total number of new article rows inserted.
+    """
+    log.info("start... wayback_ingest", ts=datetime.now().strftime("%Y/%m/%d %H:%M"),
+             date_from=date_from, date_to=date_to)
+
+    engine    = get_engine()
+    is_pg     = not engine.url.drivername.startswith("sqlite")
+    emb_model = SentenceTransformer(EMBEDDING_MODEL)
+    total_new = 0
+
+    business_days = pd.bdate_range(date_from, date_to)
+
+    with requests.Session() as session:
+        session.headers["User-Agent"] = (
+            "Mozilla/5.0 (compatible; research-bot/1.0)"
+        )
+
+        for bday in business_days:
+            day_str  = bday.strftime("%Y-%m-%d")
+            day_new  = 0
+            new_ids:   list[int] = []
+            new_texts: list[str] = []
+
+            for domain_prefix, article_pattern in WAYBACK_SOURCES:
+                log.info("cdx_query", domain=domain_prefix, day=day_str)
+                cdx_rows = _cdx_for_day(session, domain_prefix, day_str)
+                log.info("cdx_results", domain=domain_prefix, day=day_str,
+                         found=len(cdx_rows))
+                time.sleep(CDX_DELAY)
+
+                for timestamp, original_url in cdx_rows:
+                    if not _is_article_url(original_url, article_pattern):
+                        continue
+
+                    # Check existence BEFORE fetching the page (saves bandwidth)
+                    with engine.connect() as conn:
+                        if _url_in_db(conn, original_url):
+                            log.debug("url_already_in_db", url=original_url)
+                            continue
+
+                    headline = _fetch_title(session, timestamp, original_url)
+                    time.sleep(FETCH_DELAY)
+
+                    if not headline:
+                        log.debug("no_title", url=original_url)
+                        continue
+
+                    with engine.begin() as conn:
+                        art_id = _insert_article(conn, day_str, original_url,
+                                                 headline, is_pg)
+
+                    if art_id is not None:
+                        new_ids.append(art_id)
+                        new_texts.append(headline)
+                        day_new += 1
+                        log.debug("article_inserted", date=day_str,
+                                  url=original_url[:60])
+
+            # Batch-embed all new articles for this day in one model call
+            if new_ids:
+                vectors = emb_model.encode(new_texts, convert_to_numpy=True)
+                with engine.begin() as conn:
+                    for art_id, vec in zip(new_ids, vectors):
+                        _store_embedding(conn, art_id, vec, is_pg)
+
+            log.info("wayback_day_done", day=day_str, new_articles=day_new)
+            total_new += day_new
+
+    log.info("finish... wayback_ingest", ts=datetime.now().strftime("%Y/%m/%d %H:%M"),
+             total_new=total_new)
+    return total_new
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Wayback Machine scraper for Argentine financial news archives"
+    )
+    parser.add_argument("--date-from", required=True, metavar="YYYY-MM-DD",
+                        help="Start date (inclusive)")
+    parser.add_argument("--date-to",   required=True, metavar="YYYY-MM-DD",
+                        help="End date (inclusive)")
+    args = parser.parse_args()
+
+    count = fetch_and_store_wayback(args.date_from, args.date_to)
+    log.info("wayback_main_done", count=count)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/train.py
+++ b/training/train.py
@@ -193,6 +193,7 @@ def _historical_forecasts(model, target, covariates, start):
         stride=1,
         retrain=False,
         last_points_only=False,
+        overlap_end=True,
         verbose=False,
     )
 
@@ -501,10 +502,32 @@ def main():
         target = TimeSeries.from_dataframe(target_df, fill_missing_dates=False, freq="B")
     covariates = build_covariate_series(df)
 
-    target_train = target[:TRAIN_SIZE]
-    target_val   = target[:TRAIN_SIZE + VAL_SIZE]
+    # Slice by actual article-day calendar dates, not by integer position.
+    # target[:N] takes the first N *business-day* steps of the filled series,
+    # which is wrong when article days are concentrated in a short window after
+    # a multi-month gap (e.g. Dec articles + Jan gap + Feb articles).
+    from pandas.tseries.offsets import BDay as _BDay
+    _train_end = pd.Timestamp(df["date"].iloc[TRAIN_SIZE - 1])
+    _val_end   = pd.Timestamp(df["date"].iloc[TRAIN_SIZE + VAL_SIZE - 1])
+
+    target_train = target.drop_after(_train_end + _BDay(1))
+    target_val   = target.drop_after(_val_end + _BDay(1))
     target_test  = target
-    cov_full     = covariates
+
+    # Extend covariates by FORECAST_HORIZON extra business days (zero vectors)
+    # so that overlap_end=True rolling windows can complete their full horizon
+    # even when the last window starts near the series end.
+    _last_art_date = pd.Timestamp(df["date"].iloc[-1])
+    _ext_idx = pd.bdate_range(_last_art_date + _BDay(1),
+                               _last_art_date + _BDay(FORECAST_HORIZON))
+    _dim = covariates.width
+    _ext_df = pd.DataFrame(0.0, index=_ext_idx,
+                            columns=[f"emb_{i}" for i in range(_dim)])
+    _cov_df_ext = pd.concat([covariates.to_dataframe(), _ext_df])
+    cov_full  = TimeSeries.from_dataframe(_cov_df_ext, fill_missing_dates=False,
+                                          freq="B")
+    cov_train = cov_full.drop_after(_train_end + _BDay(1))
+    cov_val   = cov_full.drop_after(_val_end + _BDay(1))
 
     Path(ARTIFACTS_DIR).mkdir(parents=True, exist_ok=True)
     trials_dir = Path(ARTIFACTS_DIR) / "optuna_trials"
@@ -532,22 +555,21 @@ def main():
         model = _build_model(params, work, f"tide_trial_{trial.number}")
         model.fit(
             series=target_train,
-            past_covariates=cov_full[:TRAIN_SIZE],
-            future_covariates=cov_full[:TRAIN_SIZE],
+            past_covariates=cov_train,
+            future_covariates=cov_train,
             val_series=target_val,
-            val_past_covariates=cov_full,
-            val_future_covariates=cov_full,
+            val_past_covariates=cov_val,
+            val_future_covariates=cov_val,
             verbose=False,
         )
-        # Lag offset avoids look-back leakage; capped so at least 1 window fits
-        # (each window needs forecast_horizon steps ahead of start).
-        val_start = min(
-            TRAIN_SIZE + params["input_chunk_length"],
-            TRAIN_SIZE + VAL_SIZE - FORECAST_HORIZON,
-        )
+        # Start val rolling window at the first val article day (timestamp).
+        # Darts historical_forecasts accepts pd.Timestamp as start parameter.
+        # Use cov_full so future covariates are available beyond target_val's end
+        # (overlap_end=True allows predictions beyond the series boundary).
+        _val_start_ts = pd.Timestamp(df["date"].iloc[TRAIN_SIZE])
         val_preds = _historical_forecasts(
-            model, target_val, cov_full[:TRAIN_SIZE + VAL_SIZE],
-            val_start,
+            model, target_val, cov_full,
+            _val_start_ts,
         )
         metrics = _eval_metrics(target_val, val_preds)
         _trial_val_preds[trial.number] = val_preds
@@ -584,21 +606,19 @@ def main():
         log.info("eval_test_start", rank=rank, trial=trial.number)
         model_eval = _build_model(params, work, f"tide_eval_rank{rank}")
         model_eval.fit(
-            series=target_val,  # = target[:TRAIN_SIZE + VAL_SIZE]
-            past_covariates=cov_full[:TRAIN_SIZE + VAL_SIZE],
-            future_covariates=cov_full[:TRAIN_SIZE + VAL_SIZE],
+            series=target_val,
+            past_covariates=cov_val,
+            future_covariates=cov_val,
             val_series=target_test,
             val_past_covariates=cov_full,
             val_future_covariates=cov_full,
             verbose=False,
         )
-        test_start = min(
-            TRAIN_SIZE + VAL_SIZE + params["input_chunk_length"],
-            len(target_test) - FORECAST_HORIZON,
-        )
+        # Start test rolling window at the first test article day (timestamp).
+        _test_start_ts = pd.Timestamp(df["date"].iloc[TRAIN_SIZE + VAL_SIZE])
         test_preds = _historical_forecasts(
             model_eval, target_test, cov_full,
-            test_start,
+            _test_start_ts,
         )
         test_metrics = _eval_metrics(target_test, test_preds)
         log.info("eval_test_done", rank=rank, trial=trial.number,
@@ -680,6 +700,14 @@ def main():
         "test_samples":    TEST_SIZE,
         "training_start_date": df["date"].iloc[0].strftime("%Y-%m-%d"),
         "training_end_date":   df["date"].iloc[-1].strftime("%Y-%m-%d"),
+        "split_dates": {
+            "train_start": df["date"].iloc[0].strftime("%Y-%m-%d"),
+            "train_end":   df["date"].iloc[TRAIN_SIZE - 1].strftime("%Y-%m-%d"),
+            "val_start":   df["date"].iloc[TRAIN_SIZE].strftime("%Y-%m-%d"),
+            "val_end":     df["date"].iloc[TRAIN_SIZE + VAL_SIZE - 1].strftime("%Y-%m-%d"),
+            "test_start":  df["date"].iloc[TRAIN_SIZE + VAL_SIZE].strftime("%Y-%m-%d"),
+            "test_end":    df["date"].iloc[-1].strftime("%Y-%m-%d"),
+        },
         # Primary metrics (MAPE)
         "mape_val_best":   best["mape_val"],
         "mape_test_prod":  best["mape_test"],

--- a/training/train.py
+++ b/training/train.py
@@ -678,6 +678,8 @@ def main():
         "train_samples":   TRAIN_SIZE,
         "val_samples":     VAL_SIZE,
         "test_samples":    TEST_SIZE,
+        "training_start_date": df["date"].iloc[0].strftime("%Y-%m-%d"),
+        "training_end_date":   df["date"].iloc[-1].strftime("%Y-%m-%d"),
         # Primary metrics (MAPE)
         "mape_val_best":   best["mape_val"],
         "mape_test_prod":  best["mape_test"],

--- a/training/train.py
+++ b/training/train.py
@@ -2,7 +2,7 @@
 Training pipeline — Darts TiDE with Optuna hyperparameter optimisation.
 
 Workflow:
-  1. Optuna runs N_TRIALS, each trained on TRAIN (70%), evaluated on VAL (15%).
+  1. Optuna runs N_TRIALS, each trained on TRAIN (65%), evaluated on VAL (20%).
   2. Top-K trials by MAPE_val advance to test evaluation.
   3. Each finalist is retrained on TRAIN+VAL and evaluated on TEST (15%).
   4. The trial with best MAPE_test becomes the production model.
@@ -11,7 +11,8 @@ Workflow:
   7. Trial results written to optuna_trials table.
 
 Usage:
-    python training/train.py
+    python training/train.py [--start YYYYMMDD] [--end YYYYMMDD]
+    Default --end: 20260201 (hard-coded baseline cutoff).
 """
 import json
 import sys
@@ -41,8 +42,9 @@ log = get_logger(__name__)
 # ---------------------------------------------------------------------------
 # Split fractions
 # ---------------------------------------------------------------------------
-TRAIN_PCT = 0.70
-VAL_PCT   = 0.15
+TRAIN_PCT = 0.65
+VAL_PCT   = 0.20
+# TEST = remaining 15%
 
 INPUT_CHUNK  = 2
 OUTPUT_CHUNK = 1
@@ -52,12 +54,14 @@ STUDY_NAME   = "tide_bapro"
 # Data loading
 # ---------------------------------------------------------------------------
 
-def load_dataset(engine):
+def load_dataset(engine, date_from=None, date_to=None):
     """
     Join articles + article_embeddings + fsi_target on date.
     Mean-pool embeddings per business day.
     Only days with real article embeddings are included — days without
     articles are excluded entirely (no zero-vector fabrication).
+
+    date_from / date_to: optional YYYY-MM-DD strings to restrict the window.
     Returns DataFrame: date (datetime), vec (np.array), fsi_value (float).
     """
     with engine.connect() as conn:
@@ -109,7 +113,19 @@ def load_dataset(engine):
 
     df = pd.DataFrame(records)
     df["date"] = pd.to_datetime(df["date"])
-    return df.sort_values("date").reset_index(drop=True)
+    df = df.sort_values("date").reset_index(drop=True)
+
+    if date_from:
+        df = df[df["date"] >= pd.Timestamp(date_from)].reset_index(drop=True)
+    if date_to:
+        df = df[df["date"] <= pd.Timestamp(date_to)].reset_index(drop=True)
+
+    if df.empty:
+        raise RuntimeError(
+            f"No article days in range [{date_from}, {date_to}]. "
+            "Run embed.py and backfill for this period first."
+        )
+    return df
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +209,6 @@ def _historical_forecasts(model, target, covariates, start):
         stride=1,
         retrain=False,
         last_points_only=False,
-        overlap_end=True,
         verbose=False,
     )
 
@@ -469,12 +484,21 @@ def write_training_loss(engine, model_version, trial_number, rank_val, work_dir)
 # ---------------------------------------------------------------------------
 
 def main():
+    import argparse
     import optuna
+
+    parser = argparse.ArgumentParser(description="Train TiDE model on FSI data")
+    parser.add_argument("--start", type=str, default=None, metavar="YYYYMMDD",
+                        help="Training window start date (default: all available data)")
+    parser.add_argument("--end", type=str, default="20260201", metavar="YYYYMMDD",
+                        help="Training window end date (default: 20260201)")
+    args = parser.parse_args()
+
     optuna.logging.set_verbosity(optuna.logging.WARNING)
 
     engine = get_engine()
-    log.info("dataset_loading")
-    df = load_dataset(engine)
+    log.info("dataset_loading", date_from=args.start, date_to=args.end)
+    df = load_dataset(engine, date_from=args.start, date_to=args.end)
     n = len(df)
     assert n >= 10, f"Too few FSI samples to train: {n}"
     log.info("dataset_loaded", n=n,
@@ -514,20 +538,28 @@ def main():
     target_val   = target.drop_after(_val_end + _BDay(1))
     target_test  = target
 
-    # Extend covariates by FORECAST_HORIZON extra business days (zero vectors)
-    # so that overlap_end=True rolling windows can complete their full horizon
-    # even when the last window starts near the series end.
-    _last_art_date = pd.Timestamp(df["date"].iloc[-1])
-    _ext_idx = pd.bdate_range(_last_art_date + _BDay(1),
-                               _last_art_date + _BDay(FORECAST_HORIZON))
-    _dim = covariates.width
-    _ext_df = pd.DataFrame(0.0, index=_ext_idx,
-                            columns=[f"emb_{i}" for i in range(_dim)])
-    _cov_df_ext = pd.concat([covariates.to_dataframe(), _ext_df])
-    cov_full  = TimeSeries.from_dataframe(_cov_df_ext, fill_missing_dates=False,
-                                          freq="B")
-    cov_train = cov_full.drop_after(_train_end + _BDay(1))
-    cov_val   = cov_full.drop_after(_val_end + _BDay(1))
+    # Covariates sliced to each split; cov_full = full coverage up to last article day.
+    cov_full  = covariates
+    cov_train = covariates.drop_after(_train_end + _BDay(1))
+    cov_val   = covariates.drop_after(_val_end + _BDay(1))
+
+    # Safe rolling-window start: first article day of the split, capped so that
+    # the last prediction window fits within the target (overlap_end=False).
+    _val_start_ts  = pd.Timestamp(df["date"].iloc[TRAIN_SIZE])
+    _val_max_start = pd.Timestamp(target_val.time_index[-FORECAST_HORIZON])
+    if _val_start_ts > _val_max_start:
+        log.warning("val_start_capped_for_overlap",
+                    intended=str(_val_start_ts.date()),
+                    capped=str(_val_max_start.date()))
+        _val_start_ts = _val_max_start
+
+    _test_start_ts  = pd.Timestamp(df["date"].iloc[TRAIN_SIZE + VAL_SIZE])
+    _test_max_start = pd.Timestamp(target_test.time_index[-FORECAST_HORIZON])
+    if _test_start_ts > _test_max_start:
+        log.warning("test_start_capped_for_overlap",
+                    intended=str(_test_start_ts.date()),
+                    capped=str(_test_max_start.date()))
+        _test_start_ts = _test_max_start
 
     Path(ARTIFACTS_DIR).mkdir(parents=True, exist_ok=True)
     trials_dir = Path(ARTIFACTS_DIR) / "optuna_trials"
@@ -562,11 +594,8 @@ def main():
             val_future_covariates=cov_val,
             verbose=False,
         )
-        # Start val rolling window at the first val article day (timestamp).
-        # Darts historical_forecasts accepts pd.Timestamp as start parameter.
-        # Use cov_full so future covariates are available beyond target_val's end
-        # (overlap_end=True allows predictions beyond the series boundary).
-        _val_start_ts = pd.Timestamp(df["date"].iloc[TRAIN_SIZE])
+        # Val rolling window: start at first val article day (or earlier if needed
+        # to fit at least one full-horizon window with overlap_end=False).
         val_preds = _historical_forecasts(
             model, target_val, cov_full,
             _val_start_ts,
@@ -610,12 +639,11 @@ def main():
             past_covariates=cov_val,
             future_covariates=cov_val,
             val_series=target_test,
-            val_past_covariates=cov_full,
-            val_future_covariates=cov_full,
+            val_past_covariates=covariates,
+            val_future_covariates=covariates,
             verbose=False,
         )
-        # Start test rolling window at the first test article day (timestamp).
-        _test_start_ts = pd.Timestamp(df["date"].iloc[TRAIN_SIZE + VAL_SIZE])
+        # Test rolling window: start at first test article day (or earlier if needed).
         test_preds = _historical_forecasts(
             model_eval, target_test, cov_full,
             _test_start_ts,
@@ -654,8 +682,8 @@ def main():
     model_prod = _build_model(best_params, prod_work, "tide_bapro", progress=True)
     model_prod.fit(
         series=target,
-        past_covariates=cov_full,
-        future_covariates=cov_full,
+        past_covariates=covariates,
+        future_covariates=covariates,
         verbose=True,
     )
     model_prod.save(TIDE_MODEL_PATH)


### PR DESCRIPTION
## Summary
- Fix Entrenamiento chart clipping: use training_start/end dates from metadata instead of fsi_df.iloc[:chart_n]
- Add Indice 100 (año base) checkbox + year dropdown to both Entrenamiento and Predicciones tabs
- Fix train/val/test split boundaries: timestamp-based drop_after() slicing (not integer position)
- Add split_dates to metadata.json for dashboard shading
- Add CLI --start/--end params to train.py (default --end 20260201)
- Splits changed to 65%/20%/15% (was 70/15/15)
- Remove overlap_end=True; use Darts default (False); safe-cap rolling window start to guarantee ≥1 window
- Remove zero-vector covariate extension (only needed for overlap_end=True)
- Delete stale daily_predictions (pre-OFR model scale) and regenerate

## Test plan
- [ ] Retrain: `docker compose run --rm app python training/train.py --end 20260201`
- [ ] Verify split_dates in artifacts/metadata.json show Dec–Feb train, Feb val, Feb–Mar test
- [ ] Delete stale daily_predictions and re-run daily pipeline
- [ ] Restart dashboard; check Entrenamiento chart shows Dec 2025 onward
- [ ] Check TRAIN/VAL/TEST bands match metadata split_dates
- [ ] Test año base checkbox on both tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)